### PR TITLE
feat: Make the project into a python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,13 @@ dependencies = [
     "typer>=0.12.5",
 ]
 
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["openfoodfacts_exports"]
 
 [tool.ruff.lint]
 select = ["E", "F"]

--- a/uv.lock
+++ b/uv.lock
@@ -493,8 +493,8 @@ wheels = [
 
 [[package]]
 name = "openfoodfacts-exports"
-version = "0.2.1"
-source = { virtual = "." }
+version = "0.4.2"
+source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
     { name = "duckdb" },


### PR DESCRIPTION
### What
Make the project into a python package for easier installation.

This fixes the bug that when running the project as a script, the file `openfoodfacts_exports/types.py` is in an import conflict with `types` from the standard library (https://docs.python.org/3/library/types.html) 

```
➤ uv run openfoodfacts_exports/tasks.py
Traceback (most recent call last):
  File "openfoodfacts-exports/openfoodfacts_exports/tasks.py", line 1, in <module>
    import logging
  File "lib/python3.12/logging/__init__.py", line 26, in <module>
    import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
  File "lib/python3.12/re/__init__.py", line 124, in <module>
    import enum
  File "lib/python3.12/enum.py", line 3, in <module>
    from types import MappingProxyType, DynamicClassAttribute
  File "openfoodfacts-exports/openfoodfacts_exports/types.py", line 4, in <module>
    class ExportFlavor(str, enum.Enum):
                            ^^^^^^^^^
AttributeError: partially initialized module 'enum' has no attribute 'Enum' (most likely due to a circular import)
```