### PR TITLE
fix: receipt quantity

### DIFF
--- a/openfoodfacts_exports/exports/parquet/price.py
+++ b/openfoodfacts_exports/exports/parquet/price.py
@@ -84,7 +84,7 @@ class PriceModel(BaseModel):
     location_id: int | None = None
     date: datetime.date | None = None
     proof_id: int | None = None
-    receipt_quantity: int | None = None
+    receipt_quantity: float | None = None
     owner: str | None = None
     source: str | None = None
     created: datetime.datetime | None = None
@@ -117,7 +117,7 @@ PRICE_PRODUCT_SCHEMA = pa.schema(
         pa.field("location_id", pa.int32(), nullable=True),
         pa.field("date", pa.date32(), nullable=True),
         pa.field("proof_id", pa.int32(), nullable=True),
-        pa.field("receipt_quantity", pa.int32(), nullable=True),
+        pa.field("receipt_quantity", pa.float32(), nullable=True),
         pa.field("owner", pa.string(), nullable=True),
         pa.field("source", pa.string(), nullable=True),
         pa.field("created", pa.timestamp("us", tz="UTC"), nullable=True),


### PR DESCRIPTION
### What
Receipt quantity is not an integer but a float, this fixes that for the parquet export.

The `receipt_quantity` is not always an integer while `openfoodfacts-exports` expects it to be one.

More information:
Running the following SQL query with `prices.jsonl.gz`
```
SELECT receipt_quantity, count(*) as count
FROM read_json_auto('prices.jsonl.gz')
WHERE receipt_quantity is not NULL
GROUP BY receipt_quantity
ORDER BY count DESC
LIMIT 20;
┌──────────────────┬───────┐
│ receipt_quantity │ count │
│     varchar      │ int64 │
├──────────────────┼───────┤
│ 1.000            │ 40802 │
│ 2.000            │  1848 │
│ 3.000            │   343 │
│ 4.000            │   138 │
│ 6.000            │    54 │
│ 5.000            │    43 │
│ 7.000            │    14 │
│ 8.000            │    13 │
│ 10.000           │     9 │
│ 9.000            │     9 │
│ 12.000           │     8 │
│ 11.000           │     5 │
│ 16.000           │     2 │
│ 0.370            │     2 │ <-- not an int
│ 0.330            │     2 │ <-- not an int
│ 0.720            │     2 │ <-- not an int
│ 0.630            │     2 │ <-- not an int
│ 15.000           │     2 │
│ 0.300            │     1 │ <-- not an int
│ 0.466            │     1 │ <-- not an int
├──────────────────┴───────┤
│ 20 rows        2 columns │
└──────────────────────────┘
```
This makes the parquet schema reflect this.