### PR TITLE
feat: add categories_properties to exported food

### DIFF
--- a/openfoodfacts_exports/exports/parquet/common.py
+++ b/openfoodfacts_exports/exports/parquet/common.py
@@ -272,6 +272,28 @@ class Product(BaseModel):
         return data
 
 
+class CategoriesProperties(BaseModel, extra="forbid"):
+    """`CategoriesProperties` schema."""
+
+    ciqual_food_code: int | None = None
+    agribalyse_food_code: int | None = None
+    agribalyse_proxy_food_code: int | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_fields(cls, data: dict) -> dict:
+        """Strips the `:en` suffix and fixes the `_cod` bug in the field names.
+        `ciqual_food_code:en` becomes `ciqual_food_code`."""
+        return {fix_food_code_key(k): v for k, v in data.items()}
+
+
+def fix_food_code_key(key: str) -> str:
+    key = key.strip(":en")  # Assumes the suffix is always ":en"
+    # NOTE: Sometimes the field is _cod and not _code, probably a bug.
+    key = key.replace("_cod", "_code") if key.endswith("_cod") else key
+    return key
+
+
 PA_IMAGE_SIZE_DATATYPE = pa.struct(
     [
         pa.field("h", pa.int32(), nullable=True),
@@ -360,6 +382,15 @@ PA_OWNER_FIELD_DATATYPE = pa.list_(
             pa.field("timestamp", pa.int64()),
         ]
     )
+)
+
+
+PA_CATEGORIES_PROPERTIES_DATATYPE = pa.struct(
+    [
+        pa.field("agribalyse_food_code", pa.int32(), nullable=True),
+        pa.field("agribalyse_proxy_food_code", pa.int32(), nullable=True),
+        pa.field("ciqual_food_code", pa.int32(), nullable=True),
+    ]
 )
 
 

--- a/openfoodfacts_exports/exports/parquet/common.py
+++ b/openfoodfacts_exports/exports/parquet/common.py
@@ -387,9 +387,9 @@ PA_OWNER_FIELD_DATATYPE = pa.list_(
 
 PA_CATEGORIES_PROPERTIES_DATATYPE = pa.struct(
     [
+        pa.field("ciqual_food_code", pa.int32(), nullable=True),
         pa.field("agribalyse_food_code", pa.int32(), nullable=True),
         pa.field("agribalyse_proxy_food_code", pa.int32(), nullable=True),
-        pa.field("ciqual_food_code", pa.int32(), nullable=True),
     ]
 )
 

--- a/openfoodfacts_exports/exports/parquet/food.py
+++ b/openfoodfacts_exports/exports/parquet/food.py
@@ -3,11 +3,13 @@ import pyarrow as pa
 from pydantic import Field, field_serializer, model_validator
 
 from .common import (
+    PA_CATEGORIES_PROPERTIES_DATATYPE,
     PA_IMAGES_DATATYPE,
     PA_LANGUAGE_FIELD_DATATYPE,
     PA_NUTRIMENTS_DATATYPE,
     PA_OWNER_FIELD_DATATYPE,
     PA_PACKAGING_FIELD_DATATYPE,
+    CategoriesProperties,
     Ingredient,
     LanguageField,
     NutrimentField,
@@ -19,6 +21,7 @@ class FoodProduct(Product):
     additives_n: int | None = None
     additives_tags: list[str] | None = None
     allergens_tags: list[str] | None = None
+    categories_properties: CategoriesProperties | None = None
     ciqual_food_name_tags: list[str] | None = None
     compared_to_category: str | None = None
     ecoscore_data: dict | None = None
@@ -151,6 +154,7 @@ FOOD_PRODUCT_SCHEMA = pa.schema(
         pa.field("brands", pa.string(), nullable=True),
         pa.field("categories", pa.string(), nullable=True),
         pa.field("categories_tags", pa.list_(pa.string()), nullable=True),
+        pa.field("categories_properties", PA_CATEGORIES_PROPERTIES_DATATYPE),
         pa.field("checkers_tags", pa.list_(pa.string()), nullable=True),
         pa.field("ciqual_food_name_tags", pa.list_(pa.string()), nullable=True),
         pa.field("cities_tags", pa.list_(pa.string()), nullable=True),
@@ -263,4 +267,5 @@ FOOD_DTYPE_MAP = {
     "images": PA_IMAGES_DATATYPE,
     "nutriments": PA_NUTRIMENTS_DATATYPE,
     "packagings": PA_PACKAGING_FIELD_DATATYPE,
+    "categories_properties": PA_CATEGORIES_PROPERTIES_DATATYPE,
 }


### PR DESCRIPTION
### What
Adds `categories_properties` to `food.parquet`.

### Known issues 
- This makes the integration test fail as the examples files on GitHub don't match with the file with categories_properties.

```
FAILED tests/integration/exports/test_parquet.py::TestConvertJSONLToParquet::test_convert_jsonl_to_parquet_integration[products-min.jsonl.gz-FoodProduct-schema0-dtype_map0]
```
