### PR TITLE
feat: use pytest `tmp_path`

### DIFF
--- a/tests/unit/exports/test_csv.py
+++ b/tests/unit/exports/test_csv.py
@@ -1,5 +1,4 @@
 import gzip
-import tempfile
 from pathlib import Path
 
 import duckdb
@@ -15,58 +14,56 @@ def test_generate_mobile_app_dump_file_not_found():
         )
 
 
-def test_generate_mobile_app_dump_with_real_parquet():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        parquet_path = Path(tmpdir) / "input.parquet"
-        output_path = Path(tmpdir) / "output.tsv.gz"
+def test_generate_mobile_app_dump_with_real_parquet(tmp_path: Path):
+    parquet_path = tmp_path / "input.parquet"
+    output_path = tmp_path / "output.tsv.gz"
 
-        # Create a DuckDB connection and insert data
-        con = duckdb.connect()
-        con.execute(
-            """CREATE TABLE test_table AS
-                SELECT *
-                FROM (VALUES 
-                        ('1234567890123', 'Muesli aux fruits', '500 g',
-                        'Carrefour,Carrefour bio', 'a', 4, 'a'),
-                        ('1234567890124', 'Banana', '1', 'Chiquita', 'b', 3, 'b'),
-                        ('1234567890125', 'Brown rice', '1 kg', 'Uncle Bens', 'c',
-                        2, 'c')
-                    ) 
-                AS t(code, product_name, quantity, brands, nutriscore_grade, nova_group,
-                ecoscore_grade)
-            """
+    # Create a DuckDB connection and insert data
+    con = duckdb.connect()
+    con.execute(
+        """CREATE TABLE test_table AS
+            SELECT *
+            FROM (VALUES 
+                    ('1234567890123', 'Muesli aux fruits', '500 g',
+                    'Carrefour,Carrefour bio', 'a', 4, 'a'),
+                    ('1234567890124', 'Banana', '1', 'Chiquita', 'b', 3, 'b'),
+                    ('1234567890125', 'Brown rice', '1 kg', 'Uncle Bens', 'c',
+                    2, 'c')
+                ) 
+            AS t(code, product_name, quantity, brands, nutriscore_grade, nova_group,
+            ecoscore_grade)
+        """
+    )
+
+    # Export the table to a Parquet file
+    con.execute(f"COPY test_table TO '{parquet_path}' (FORMAT 'parquet')")
+
+    generate_mobile_app_dump(parquet_path, output_path)
+
+    assert output_path.exists()
+    with gzip.open(output_path, "rt") as f:
+        lines = f.readlines()
+        assert len(lines) == 4
+        header = lines[0]
+        assert "\t" in header
+        fields = header.strip().split("\t")
+
+        for field_name in (
+            "code",
+            "product_name",
+            "quantity",
+            "brands",
+            "nutrition_grade_fr",
+            "nova_group",
+            "ecoscore_grade",
+        ):
+            assert field_name in fields
+
+        assert lines[1].strip() == (
+            "1234567890123\tMuesli aux fruits\t500 g\tCarrefour,Carrefour bio"
+            "\ta\t4\ta"
         )
-
-        # Export the table to a Parquet file
-        con.execute(f"COPY test_table TO '{parquet_path}' (FORMAT 'parquet')")
-
-        generate_mobile_app_dump(parquet_path, output_path)
-
-        assert output_path.exists()
-        with gzip.open(output_path, "rt") as f:
-            lines = f.readlines()
-            assert len(lines) == 4
-            header = lines[0]
-            assert "\t" in header
-            fields = header.strip().split("\t")
-
-            for field_name in (
-                "code",
-                "product_name",
-                "quantity",
-                "brands",
-                "nutrition_grade_fr",
-                "nova_group",
-                "ecoscore_grade",
-            ):
-                assert field_name in fields
-
-            assert lines[1].strip() == (
-                "1234567890123\tMuesli aux fruits\t500 g\tCarrefour,Carrefour bio"
-                "\ta\t4\ta"
-            )
-            assert lines[2].strip() == "1234567890124\tBanana\t1\tChiquita\tb\t3\tb"
-            assert (
-                lines[3].strip()
-                == "1234567890125\tBrown rice\t1 kg\tUncle Bens\tc\t2\tc"
-            )
+        assert lines[2].strip() == "1234567890124\tBanana\t1\tChiquita\tb\t3\tb"
+        assert (
+            lines[3].strip() == "1234567890125\tBrown rice\t1 kg\tUncle Bens\tc\t2\tc"
+        )


### PR DESCRIPTION
### What
- Use pytest `tmp_path` (https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html) instead of tempfile in tests.
