### PR TITLE
fix: support new `images` schema by converting to legacy schema

### DIFF
--- a/openfoodfacts_exports/exports/parquet/common.py
+++ b/openfoodfacts_exports/exports/parquet/common.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pyarrow as pa
 from huggingface_hub import HfApi
+from openfoodfacts.images import convert_to_legacy_schema
 from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
@@ -249,13 +250,15 @@ class Product(BaseModel):
         key as the key and the image data as the value.
 
         To make the schema compatible with Parquet, we convert these fields
-        into a list of dictionaries with `key`, `imgid`, `rev`, `sizes`, `uploaded_t`,
-        and `uploader` keys. We copy the image key (ex: `3`, `nutrition_fr`,...)
-        from the original dictionary and add it as a field under the `key` key.
+        into a list of dictionaries with `key`, `imgid`, `rev`, `sizes`,
+        `uploaded_t`, and `uploader` keys. We copy the image key (ex: `3`,
+        `nutrition_fr`,...) from the original dictionary and add it as a field
+        under the `key` key.
         """
         images = data.pop("images", None)
         data["images"] = []
         if images:
+            images = convert_to_legacy_schema(images)
             for key, value in images.items():
                 data["images"].append({"key": key, **value})
         return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "huggingface-hub>=0.26.2",
     "minio>=7.2.10",
     "more-itertools>=10.5.0",
-    "openfoodfacts>=2.2.0",
+    "openfoodfacts==2.5.2",
     "orjson>=3.10.11",
     "pyarrow>=18.0.0",
     "pytz>=2024.2",

--- a/tests/unit/exports/test_parquet.py
+++ b/tests/unit/exports/test_parquet.py
@@ -8,6 +8,7 @@ from openfoodfacts_exports.exports.parquet.beauty import (
     BEAUTY_PRODUCT_SCHEMA,
     BeautyProduct,
 )
+from openfoodfacts_exports.exports.parquet.common import Product
 
 
 class TestConvertJSONLToParquet:
@@ -21,3 +22,114 @@ class TestConvertJSONLToParquet:
                 schema=BEAUTY_PRODUCT_SCHEMA,
                 dtype_map=BEAUTY_DTYPE_MAP,
             )
+
+
+PARSED_IMAGES_WITH_LEGACY_SCHEMA = [
+    {
+        "key": "1",
+        "sizes": {
+            "100": {"h": 100, "w": 56},
+            "400": {"h": 400, "w": 225},
+            "full": {"h": 3555, "w": 2000},
+        },
+        "uploaded_t": "1490702616",
+        "uploader": "user1",
+    },
+    {
+        "key": "nutrition_fr",
+        "angle": None,
+        "geometry": "0x0-0-0",
+        "imgid": "1",
+        "normalize": "0",
+        "ocr": 1,
+        "orientation": "0",
+        "rev": "18",
+        "sizes": {
+            "100": {"h": 53, "w": 100},
+            "200": {"h": 107, "w": 200},
+            "400": {"h": 213, "w": 400},
+            "full": {"h": 1093, "w": 2050},
+        },
+        "white_magic": "0",
+        "x1": None,
+        "x2": None,
+        "y1": None,
+        "y2": None,
+    },
+]
+
+
+IMAGES_WITH_NEW_SCHEMA = {
+    "uploaded": {
+        "1": {
+            "sizes": {
+                "100": {
+                    "h": 100,
+                    "w": 56,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/1.100.jpg",
+                },
+                "400": {
+                    "h": 400,
+                    "w": 225,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/1.400.jpg",
+                },
+                "full": {
+                    "h": 3555,
+                    "w": 2000,
+                    "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/1.jpg",
+                },
+            },
+            "uploaded_t": "1490702616",
+            "uploader": "user1",
+        },
+    },
+    "selected": {
+        "nutrition": {
+            "fr": {
+                "imgid": "1",
+                "rev": "18",
+                "sizes": {
+                    "100": {
+                        "h": 53,
+                        "w": 100,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.100.jpg",
+                    },
+                    "200": {
+                        "h": 107,
+                        "w": 200,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.200.jpg",
+                    },
+                    "400": {
+                        "h": 213,
+                        "w": 400,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.400.jpg",
+                    },
+                    "full": {
+                        "h": 1093,
+                        "w": 2050,
+                        "url": "https://images.openfoodfacts.org/images/products/326/385/950/6216/nutrition_fr.18.full.jpg",
+                    },
+                },
+                "generation": {
+                    "white_magic": "0",
+                    "x1": None,
+                    "x2": None,
+                    "y1": None,
+                    "y2": None,
+                    "normalize": "0",
+                    "ocr": 1,
+                    "orientation": "0",
+                    "angle": None,
+                    "geometry": "0x0-0-0",
+                },
+            },
+        }
+    },
+}
+
+
+class TestProduct:
+    def test_parse_images(self):
+        assert Product.parse_images({"images": IMAGES_WITH_NEW_SCHEMA}) == {
+            "images": PARSED_IMAGES_WITH_LEGACY_SCHEMA
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -479,16 +479,16 @@ wheels = [
 
 [[package]]
 name = "openfoodfacts"
-version = "2.2.0"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/8c/376fc0ae1ee2abd2f7b4726474fe58b9725f0e368cfd390aa312738be6c1/openfoodfacts-2.2.0.tar.gz", hash = "sha256:e79ec1292238078de5e4857a19a7ccc66ca99b766311a9d7e60e9bf5315ac762", size = 45720 }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/d5/6a72d665a3519bacf8ab907dc1ba8351f42e0ec9af80546e183fcc871cc9/openfoodfacts-2.5.2.tar.gz", hash = "sha256:372967e4e965ce9c504a6430fb59b1801950c2157e507b96f7e1c8938789c680", size = 53141 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/88/ff3197960a9f587e29578ea62697edae4a499e950c8641b20944f2ca1099/openfoodfacts-2.2.0-py3-none-any.whl", hash = "sha256:172c953fd5727ffbe23bd2839afebc15cc346c3e186976e98b3d37026a90ba5b", size = 48291 },
+    { url = "https://files.pythonhosted.org/packages/b3/46/991e9706052774c55fd4c0e54f4f737108eef5e0d0f02de1506064e25c1d/openfoodfacts-2.5.2-py3-none-any.whl", hash = "sha256:6081f541d137a60d73c514d8ca19455fd0e4eb9b249a9f5f1c84686d22cca97c", size = 57715 },
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.26.2" },
     { name = "minio", specifier = ">=7.2.10" },
     { name = "more-itertools", specifier = ">=10.5.0" },
-    { name = "openfoodfacts", specifier = ">=2.2.0" },
+    { name = "openfoodfacts", specifier = "==2.5.2" },
     { name = "orjson", specifier = ">=3.10.11" },
     { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytz", specifier = ">=2024.2" },


### PR DESCRIPTION
See openfoodfacts/openfoodfacts-server#11818 for more details about the schema changes.
