### PR TITLE
fix: enable pushing mobile dump to S3 in production

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -37,7 +37,7 @@ jobs:
         # configurations
         echo "ENVIRONMENT=prod" >> $GITHUB_ENV
         echo "ENABLE_HF_PUSH=1" >> $GITHUB_ENV
-        echo "ENABLE_S3_PUSH=0" >> $GITHUB_ENV
+        echo "ENABLE_S3_PUSH=1" >> $GITHUB_ENV
         # deploy target
         echo "SSH_PROXY_HOST=45.147.209.254" >> $GITHUB_ENV
         echo "SSH_USERNAME=off" >> $GITHUB_ENV


### PR DESCRIPTION
The push was disabled in production.