### PR TITLE
 feat: add an update listener that updates images on S3

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -3,8 +3,8 @@ name: Docker Compose Deployment CI
 on:
   push:
     branches:
-    - main
-    - deploy-*
+      - main
+      - deploy-*
     tags:
       - v*.*.*
 
@@ -18,156 +18,164 @@ jobs:
     environment: ${{ matrix.env }}
     concurrency: ${{ matrix.env }}
     steps:
-    - name: Set various variable for staging deployment
-      if: matrix.env == 'off-exports-net'
-      run: |
-        # configurations
-        echo "ENVIRONMENT=preprod" >> $GITHUB_ENV
-        echo "ENABLE_HF_PUSH=0" >> $GITHUB_ENV
-        echo "ENABLE_S3_PUSH=0" >> $GITHUB_ENV
-        # deploy target
-        echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
-        echo "SSH_USERNAME=off" >> $GITHUB_ENV
-        echo "SSH_PROXY_USERNAME=off" >> $GITHUB_ENV
-        echo "SSH_HOST=10.1.0.200" >> $GITHUB_ENV
+      - name: Set various variable for staging deployment
+        if: matrix.env == 'off-exports-net'
+        run: |
+          # configurations
+          echo "ENVIRONMENT=preprod" >> $GITHUB_ENV
+          echo "ENABLE_HF_PUSH=0" >> $GITHUB_ENV
+          echo "ENABLE_S3_PUSH=0" >> $GITHUB_ENV
+          # deploy target
+          echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
+          echo "SSH_USERNAME=off" >> $GITHUB_ENV
+          echo "SSH_PROXY_USERNAME=off" >> $GITHUB_ENV
+          echo "SSH_HOST=10.1.0.200" >> $GITHUB_ENV
+          echo "REDIS_UPDATE_HOST=redis.po_webnet" >> $GITHUB_ENV
+          echo "REDIS_UPDATE_PORT=6379" >> $GITHUB_ENV
 
-    - name: Set various variable for production deployment
-      if: matrix.env == 'off-exports-org'
-      run: |
-        # configurations
-        echo "ENVIRONMENT=prod" >> $GITHUB_ENV
-        echo "ENABLE_HF_PUSH=1" >> $GITHUB_ENV
-        echo "ENABLE_S3_PUSH=1" >> $GITHUB_ENV
-        # deploy target
-        echo "SSH_PROXY_HOST=45.147.209.254" >> $GITHUB_ENV
-        echo "SSH_USERNAME=off" >> $GITHUB_ENV
-        echo "SSH_PROXY_USERNAME=off" >> $GITHUB_ENV
-        echo "SSH_PROTOCOL=tcp" >> $GITHUB_ENV
-        echo "SSH_HOST=10.3.0.200" >> $GITHUB_ENV
+      - name: Set various variable for production deployment
+        if: matrix.env == 'off-exports-org'
+        run: |
+          # configurations
+          echo "ENVIRONMENT=prod" >> $GITHUB_ENV
+          echo "ENABLE_HF_PUSH=1" >> $GITHUB_ENV
+          echo "ENABLE_S3_PUSH=1" >> $GITHUB_ENV
+          # deploy target
+          echo "SSH_PROXY_HOST=45.147.209.254" >> $GITHUB_ENV
+          echo "SSH_USERNAME=off" >> $GITHUB_ENV
+          echo "SSH_PROXY_USERNAME=off" >> $GITHUB_ENV
+          echo "SSH_PROTOCOL=tcp" >> $GITHUB_ENV
+          echo "SSH_HOST=10.3.0.200" >> $GITHUB_ENV
+          echo "REDIS_UPDATE_HOST=10.3.0.101" >> $GITHUB_ENV
+          echo "REDIS_UPDATE_PORT=6379" >> $GITHUB_ENV
 
-    - name: Wait for container build workflow
-      uses: tomchv/wait-my-workflow@v1.1.0
-      id: wait-build
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: build
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        intervalSeconds: 10
-        timeoutSeconds: 600 # 10m
+      - name: Wait for container build workflow
+        uses: tomchv/wait-my-workflow@v1.1.0
+        id: wait-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: build
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          intervalSeconds: 10
+          timeoutSeconds: 600 # 10m
 
-    - name: Do something if build isn't launched
-      if: steps.wait-build.outputs.conclusion == 'not found'
-      run: echo job does not exist && true
+      - name: Do something if build isn't launched
+        if: steps.wait-build.outputs.conclusion == 'not found'
+        run: echo job does not exist && true
 
-    - name: Do something if build fail
-      if: steps.wait-build.outputs.conclusion == 'failure'
-      run: echo fail && false # fail if build fail
+      - name: Do something if build fail
+        if: steps.wait-build.outputs.conclusion == 'failure'
+        run: echo fail && false # fail if build fail
 
-    - name: Do something if build timeout
-      if: steps.wait-build.outputs.conclusion == 'timed_out'
-      run: echo Timeout && false # fail if build time out
+      - name: Do something if build timeout
+        if: steps.wait-build.outputs.conclusion == 'timed_out'
+        run: echo Timeout && false # fail if build time out
 
-    - name: Checkout git repository
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ env.SSH_HOST }}
-        username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        proxy_host: ${{ env.SSH_PROXY_HOST }}
-        proxy_username: ${{ env.SSH_PROXY_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
-        script: |
-          # Clone Git repository if not already there
-          [ ! -d '${{ matrix.env }}' ] && git clone --depth 1 https://github.com/${{ github.repository }} ${{ matrix.env }} --no-single-branch 2>&1
+      - name: Checkout git repository
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.SSH_HOST }}
+          username: ${{ env.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          proxy_host: ${{ env.SSH_PROXY_HOST }}
+          proxy_username: ${{ env.SSH_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: false
+          script: |
+            # Clone Git repository if not already there
+            [ ! -d '${{ matrix.env }}' ] && git clone --depth 1 https://github.com/${{ github.repository }} ${{ matrix.env }} --no-single-branch 2>&1
 
-          # Go to repository directory
-          cd ${{ matrix.env }}
+            # Go to repository directory
+            cd ${{ matrix.env }}
 
-          # Fetch newest commits (in case it wasn't freshly cloned)
-          git fetch --depth 1
+            # Fetch newest commits (in case it wasn't freshly cloned)
+            git fetch --depth 1
 
-          # Checkout current commit SHA
-          git checkout -qf ${{ github.sha }}
+            # Checkout current commit SHA
+            git checkout -qf ${{ github.sha }}
 
-    - name: Set environment variables
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ env.SSH_HOST }}
-        username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        proxy_host: ${{ env.SSH_PROXY_HOST }}
-        proxy_username: ${{ env.SSH_PROXY_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
-        script: |
-          # Go to repository directory
-          cd ${{ matrix.env }}
+      - name: Set environment variables
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.SSH_HOST }}
+          username: ${{ env.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          proxy_host: ${{ env.SSH_PROXY_HOST }}
+          proxy_username: ${{ env.SSH_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: false
+          script: |
+            # Go to repository directory
+            cd ${{ matrix.env }}
 
-          # new env
-          rm .env
-          touch .env
-          # Set Docker Compose variables
-          echo "DOCKER_CLIENT_TIMEOUT=120" >> .env
-          echo "COMPOSE_HTTP_TIMEOUT=120" >> .env
-          echo "COMPOSE_PROJECT_NAME=off-exports" >> .env
-          echo "COMPOSE_PATH_SEPARATOR=;" >> .env
-          echo "COMPOSE_FILE=docker-compose.yml;docker/prod.yml" >> .env
-          echo "TAG=sha-${{ github.sha }}" >> .env
-          echo "RESTART_POLICY=always" >> .env
+            # new env
+            rm .env
+            touch .env
+            # Set Docker Compose variables
+            echo "DOCKER_CLIENT_TIMEOUT=120" >> .env
+            echo "COMPOSE_HTTP_TIMEOUT=120" >> .env
+            echo "COMPOSE_PROJECT_NAME=off-exports" >> .env
+            echo "COMPOSE_PATH_SEPARATOR=;" >> .env
+            echo "COMPOSE_FILE=docker-compose.yml;docker/prod.yml" >> .env
+            echo "TAG=sha-${{ github.sha }}" >> .env
+            echo "RESTART_POLICY=always" >> .env
 
-          # App environment variables
-          echo "ENVIRONMENT=${{ env.ENVIRONMENT }}" >> .env
-          echo "REDIS_HOST=redis" >> .env
-          echo "NUM_RQ_WORKERS=4" >> .env
-          echo "ENABLE_HF_PUSH=${{ env.ENABLE_HF_PUSH }}" >> .env
-          echo "ENABLE_S3_PUSH=${{ env.ENABLE_S3_PUSH }}" >> .env
+            # Redis configuration
+            echo "REDIS_UPDATE_HOST=${{ env.REDIS_UPDATE_HOST }}" >> .env
+            echo "REDIS_UPDATE_PORT=${{ env.REDIS_UPDATE_PORT }}" >> .env
 
-          # Secrets
-          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
-          echo "HF_TOKEN=${{ secrets.HF_TOKEN }}" >> .env
-          echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" >> .env
-          echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" >> .env
+            # App environment variables
+            echo "ENVIRONMENT=${{ env.ENVIRONMENT }}" >> .env
+            echo "REDIS_HOST=redis" >> .env
+            echo "NUM_RQ_WORKERS=4" >> .env
+            echo "ENABLE_HF_PUSH=${{ env.ENABLE_HF_PUSH }}" >> .env
+            echo "ENABLE_S3_PUSH=${{ env.ENABLE_S3_PUSH }}" >> .env
 
-    - name: Create Docker volumes
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ env.SSH_HOST }}
-        username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        proxy_host: ${{ env.SSH_PROXY_HOST }}
-        proxy_username: ${{ env.SSH_PROXY_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
-        script: |
-          cd ${{ matrix.env }}
-          make create_external_volumes
+            # Secrets
+            echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
+            echo "HF_TOKEN=${{ secrets.HF_TOKEN }}" >> .env
+            echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" >> .env
+            echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" >> .env
 
-    - name: Start services
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ env.SSH_HOST }}
-        username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        proxy_host: ${{ env.SSH_PROXY_HOST }}
-        proxy_username: ${{ env.SSH_PROXY_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
-        script: |
-          cd ${{ matrix.env }}
-          make up
+      - name: Create Docker volumes
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.SSH_HOST }}
+          username: ${{ env.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          proxy_host: ${{ env.SSH_PROXY_HOST }}
+          proxy_username: ${{ env.SSH_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: false
+          script: |
+            cd ${{ matrix.env }}
+            make create_external_volumes
 
-    - name: Cleanup obsolete Docker objects
-      uses: appleboy/ssh-action@master
-      if: ${{ always() }}
-      with:
-        host: ${{ env.SSH_HOST }}
-        username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        proxy_host: ${{ env.SSH_PROXY_HOST }}
-        proxy_username: ${{ env.SSH_PROXY_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-        script_stop: false
-        script: |
-          cd ${{ matrix.env }}
-          make prune
+      - name: Start services
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.SSH_HOST }}
+          username: ${{ env.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          proxy_host: ${{ env.SSH_PROXY_HOST }}
+          proxy_username: ${{ env.SSH_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: false
+          script: |
+            cd ${{ matrix.env }}
+            make up
+
+      - name: Cleanup obsolete Docker objects
+        uses: appleboy/ssh-action@master
+        if: ${{ always() }}
+        with:
+          host: ${{ env.SSH_HOST }}
+          username: ${{ env.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          proxy_host: ${{ env.SSH_PROXY_HOST }}
+          proxy_username: ${{ env.SSH_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: false
+          script: |
+            cd ${{ matrix.env }}
+            make prune

--- a/openfoodfacts_exports/main.py
+++ b/openfoodfacts_exports/main.py
@@ -18,6 +18,19 @@ def run_scheduler():
 
 
 @app.command()
+def run_update_listener():
+    """Run the update listener, that listen for product updates and triggers appropriate
+    actions."""
+    from openfoodfacts.utils import get_logger
+
+    from openfoodfacts_exports.update_listener import run_update_listener
+
+    # configure root logger
+    get_logger()
+    run_update_listener()
+
+
+@app.command()
 def run_worker(queues: list[str], burst: bool = False):
     """Run a worker for the given queues."""
     from openfoodfacts.utils import get_logger

--- a/openfoodfacts_exports/settings.py
+++ b/openfoodfacts_exports/settings.py
@@ -20,3 +20,17 @@ ENABLE_HF_PUSH = int(os.getenv("ENABLE_HF_PUSH", "0"))
 ENABLE_S3_PUSH = int(os.getenv("ENABLE_S3_PUSH", "0"))
 
 AWS_S3_DATASET_BUCKET = os.getenv("AWS_S3_DATASET_BUCKET", "openfoodfacts-ds")
+AWS_S3_IMAGE_BUCKET = os.getenv("AWS_S3_IMAGE_BUCKET", "openfoodfacts-images")
+
+# Remote Redis where Product Opener publishes product updates in a stream
+REDIS_UPDATE_HOST = os.environ.get("REDIS_UPDATE_HOST", "localhost")
+REDIS_UPDATE_PORT = int(os.environ.get("REDIS_UPDATE_PORT", 6379))
+
+
+# Name of the Redis stream where Product Opener publishes product updates
+PRODUCT_UPDATE_STREAM_NAME = os.environ.get(
+    "PRODUCT_UPDATE_STREAM_NAME", "product_updates"
+)
+REDIS_LATEST_ID_KEY = os.environ.get(
+    "REDIS_LATEST_ID_KEY", "openfoodfacts_exports:product_updates:latest_id"
+)

--- a/openfoodfacts_exports/tasks.py
+++ b/openfoodfacts_exports/tasks.py
@@ -1,11 +1,23 @@
+import gzip
+import io
 import logging
 from pathlib import Path
 
-from openfoodfacts import Flavor, get_dataset
+from openfoodfacts import Environment, Flavor, get_dataset
 from openfoodfacts.dataset import DEFAULT_CACHE_DIR
+from openfoodfacts.images import (
+    _generate_file_path,
+    generate_image_url,
+    generate_json_ocr_url,
+)
 from openfoodfacts.types import DatasetType
-from openfoodfacts.utils import download_file, should_download_file
+from openfoodfacts.utils import (
+    download_file,
+    get_asset_from_url,
+    should_download_file,
+)
 
+from openfoodfacts_exports import settings
 from openfoodfacts_exports.exports.csv.mobile import generate_push_mobile_app_dump
 from openfoodfacts_exports.exports.parquet import PARQUET_DATASET_PATH, export_parquet
 from openfoodfacts_exports.exports.parquet.price import PRICE_DATASET_PATH
@@ -13,20 +25,21 @@ from openfoodfacts_exports.exports.parquet.price import (
     export_parquet as export_price_parquet,
 )
 from openfoodfacts_exports.types import ExportFlavor
+from openfoodfacts_exports.utils import get_minio_client
 from openfoodfacts_exports.workers.queues import high_queue
 
 logger = logging.getLogger(__name__)
 
 
-def export_job(flavor: ExportFlavor) -> None:
+def export_job(export_flavor: ExportFlavor) -> None:
     """Download the JSONL dataset and launch exports through new rq jobs."""
-    logger.info("Start export job for flavor %s", flavor)
+    logger.info("Start export job for flavor %s", export_flavor)
 
-    if flavor == ExportFlavor.op:
+    if export_flavor == ExportFlavor.op:
         export_price_job()
         return
 
-    flavor = Flavor[flavor]
+    flavor = Flavor[export_flavor]
     dataset_path = get_dataset(
         flavor=flavor, dataset_type=DatasetType.jsonl, download_newer=True
     )
@@ -36,7 +49,7 @@ def export_job(flavor: ExportFlavor) -> None:
             export_parquet,
             dataset_path,
             PARQUET_DATASET_PATH[flavor],
-            flavor,
+            export_flavor,
             job_timeout="3h",
         )
 
@@ -107,3 +120,89 @@ def get_price_dataset(
     logger.info("Downloading dataset, saving it in %s", dataset_path)
     download_file(url, dataset_path)
     return dataset_path
+
+
+def upload_new_image_to_s3(
+    image_id: str, barcode: str, flavor: Flavor, environment: Environment
+) -> None:
+    """Upload assets to S3 after a new image was uploaded to Product Opener.
+
+    The following assets are uploaded:
+    - Image (original and 400px version)
+    - OCR result, gzipped
+
+    Args:
+        image_id (str): The ID of the image.
+        barcode (str): The barcode of the product.
+        flavor (Flavor): The flavor of the image.
+        environment (Environment): The environment of the image.
+    """
+    if not settings.ENABLE_S3_PUSH:
+        logger.debug("S3 push is disabled, skipping upload")
+        return
+
+    client = get_minio_client()
+    for image_prefix in (image_id, f"{image_id}.400"):
+        image_url = generate_image_url(
+            barcode,
+            image_prefix,
+            flavor=flavor,
+            environment=environment,
+        )
+        image_asset = get_asset_from_url(asset_url=image_url, error_raise=False)
+        image_base_path = _generate_file_path(
+            code=barcode, image_id=image_prefix, suffix=".jpg"
+        )
+        if image_asset.response is not None and image_asset.response.status_code == 200:
+            s3_path = f"data{image_base_path}"
+            image_fp = io.BytesIO(image_asset.response.content)
+            logger.info(
+                "Uploading image to %s/%s", settings.AWS_S3_IMAGE_BUCKET, s3_path
+            )
+            client.put_object(
+                bucket_name=settings.AWS_S3_IMAGE_BUCKET,
+                object_name=s3_path,
+                data=image_fp,
+                length=len(image_asset.response.content),
+            )
+    ocr_url = generate_json_ocr_url(
+        barcode,
+        image_id,
+        flavor=flavor,
+        environment=environment,
+    )
+    ocr_asset = get_asset_from_url(asset_url=ocr_url, error_raise=False)
+    ocr_base_path = _generate_file_path(
+        code=barcode, image_id=image_id, suffix=".json.gz"
+    )
+    if ocr_asset.response is not None and ocr_asset.response.status_code == 200:
+        s3_path = f"data{ocr_base_path}"
+        compressed_bytes = gzip.compress(ocr_asset.response.content)
+        ocr_fp = io.BytesIO(compressed_bytes)
+        logger.info(
+            "Uploading OCR file to %s/%s", settings.AWS_S3_IMAGE_BUCKET, s3_path
+        )
+        client.put_object(
+            bucket_name=settings.AWS_S3_IMAGE_BUCKET,
+            object_name=s3_path,
+            data=ocr_fp,
+            length=len(compressed_bytes),
+        )
+
+
+def delete_image_from_s3(image_id: str, barcode: str) -> None:
+    """Delete images and OCR results from S3, after the image deletion from Product
+    Opener."""
+    if not settings.ENABLE_S3_PUSH:
+        logger.debug("S3 push is disabled, skipping deletion")
+        return
+
+    client = get_minio_client()
+    for suffix in (".jpg", ".400.jpg", ".json.gz"):
+        file_path = _generate_file_path(barcode, image_id, suffix=suffix)
+        s3_path = f"data{file_path}"
+        logger.info("Deleting file %s", s3_path)
+        client.remove_object(
+            bucket_name=settings.AWS_S3_IMAGE_BUCKET,
+            object_name=s3_path,
+        )

--- a/openfoodfacts_exports/update_listener.py
+++ b/openfoodfacts_exports/update_listener.py
@@ -1,0 +1,102 @@
+import logging
+
+import backoff
+from openfoodfacts import Environment, Flavor
+from openfoodfacts.redis import ProductUpdateEvent
+from openfoodfacts.redis import UpdateListener as BaseUpdateListener
+from redis import Redis
+from redis.exceptions import ConnectionError
+
+from openfoodfacts_exports import settings
+from openfoodfacts_exports.tasks import delete_image_from_s3, upload_new_image_to_s3
+
+logger = logging.getLogger(__name__)
+
+
+def get_redis_client():
+    """Get the Redis client where Product Opener publishes its product updates."""
+    return Redis(
+        host=settings.REDIS_UPDATE_HOST,
+        port=settings.REDIS_UPDATE_PORT,
+        decode_responses=True,
+    )
+
+
+class UpdateListener(BaseUpdateListener):
+    def process_redis_update(self, event: ProductUpdateEvent):
+        logger.debug("New update: %s", event)
+
+        if not event.code:
+            logger.warning("Product code is empty or null ('%s'), skipping", event.code)
+            return
+
+        action = event.action
+        if action == "deleted":
+            logger.info("Product %s has been deleted", event.code)
+        elif action == "updated":
+            if event.is_image_upload():
+                self.process_image_upload(event)
+            elif event.is_image_deletion():
+                self.process_image_deletion(event)
+
+    def process_image_upload(self, event: ProductUpdateEvent):
+        # A new image was uploaded
+        image_id = event.diffs["uploaded_images"]["add"][0]  # type: ignore
+        logger.info("Image %s was added on product %s", image_id, event.code)
+        environment = (
+            Environment.org if settings.ENVIRONMENT == "prod" else Environment.net
+        )
+        flavor = Flavor[event.flavor]
+        upload_new_image_to_s3(
+            image_id=image_id,
+            barcode=event.code,
+            flavor=flavor,
+            environment=environment,
+        )
+
+    def process_image_deletion(self, event: ProductUpdateEvent):
+        image_id = event.diffs["uploaded_images"]["delete"][0]  # type: ignore
+        logger.info(
+            "Image %s for product %s has been deleted",
+            image_id,
+            event.code,
+        )
+        delete_image_from_s3(image_id=image_id, barcode=event.code)
+
+
+@backoff.on_exception(
+    backoff.expo,
+    ConnectionError,
+    max_value=60,  # we wait at most 60 seconds between retries
+    jitter=backoff.random_jitter,
+    on_backoff=lambda details: logger.error(
+        "Redis connection error (attempt %d): %s. Retrying in %.1f seconds...",
+        details["tries"],
+        details["exception"],
+        details["wait"],
+    ),
+    on_giveup=lambda details: logger.critical(
+        "Max retries (%d) reached. Update listener is terminating.", details["tries"]
+    ),
+)
+def run_update_listener():
+    """Run the update import daemon.
+
+    This daemon listens to the Redis stream containing information about
+    product updates and triggers appropriate actions.
+    """
+    logger.info("Starting Redis update listener...")
+    while True:
+        try:
+            redis_client = get_redis_client()
+            update_listener = UpdateListener(
+                redis_client=redis_client,
+                redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
+                product_updates_stream_name=settings.PRODUCT_UPDATE_STREAM_NAME,
+            )
+            update_listener.run()
+        except Exception as e:
+            logger.critical(
+                "Unexpected error in update listener: %s", str(e), exc_info=True
+            )
+            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "apscheduler>=3.10.4",
+    "backoff~=2.2.1",
     "duckdb==1.1.2",
     "huggingface-hub>=0.26.2",
     "minio>=7.2.10",
@@ -40,6 +41,7 @@ dev = [
     "pre-commit>=4.0.1",
     "pytest-cov>=6.0.0",
     "pytest>=8.3.3",
+    "pytest-mock~=3.15.1",
     "ruff>=0.7.3",
     "types-pytz>=2024.2.0.20241003",
     "types-toml>=0.10.8.20240310",

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,0 +1,158 @@
+import gzip
+from unittest.mock import MagicMock, patch
+
+from openfoodfacts import Environment, Flavor
+from openfoodfacts.utils import AssetDownloadItem
+
+from openfoodfacts_exports import tasks
+
+
+class TestUploadNewImageToS3:
+    @patch("openfoodfacts_exports.tasks.settings.ENABLE_S3_PUSH", False)
+    def test_upload_new_image_to_s3_disabled(self, mocker):
+        """When ENABLE_S3_PUSH is False, return early without calling S3/asset APIs."""
+        mock_client = mocker.patch("openfoodfacts_exports.tasks.get_minio_client")
+        mock_asset = mocker.patch("openfoodfacts_exports.tasks.get_asset_from_url")
+        tasks.upload_new_image_to_s3("img1", "123", Flavor.off, Environment.org)
+        mock_client.assert_not_called()
+        mock_asset.assert_not_called()
+
+    @patch("openfoodfacts_exports.tasks.settings.ENABLE_S3_PUSH", True)
+    def test_upload_new_image_to_s3_success(self, mocker):
+        """All assets return 200: 3 put_object calls (original, 400px, gzipped OCR)."""
+        image_content = ("x" * 200).encode("utf-8")
+        ocr_content = '{"ocr": "data"}'.encode("utf-8")
+
+        def fake_get_asset_from_url(asset_url, **kwargs):
+            content = ocr_content if asset_url.endswith(".json") else image_content
+            return AssetDownloadItem(
+                url=asset_url, response=MagicMock(status_code=200, content=content)
+            )
+
+        mock_client = mocker.MagicMock()
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_minio_client", return_value=mock_client
+        )
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_asset_from_url", fake_get_asset_from_url
+        )
+        tasks.upload_new_image_to_s3(
+            image_id="1",
+            barcode="3270160396337",
+            flavor=Flavor.off,
+            environment=Environment.org,
+        )
+
+        assert mock_client.put_object.call_count == 3
+
+        calls = mock_client.put_object.call_args_list
+        buckets = [c.kwargs["bucket_name"] for c in calls]
+        assert all(b == "openfoodfacts-images" for b in buckets)
+
+        object_names = [c.kwargs["object_name"] for c in calls]
+        assert object_names == [
+            "data/327/016/039/6337/1.jpg",
+            "data/327/016/039/6337/1.400.jpg",
+            "data/327/016/039/6337/1.json.gz",
+        ]
+
+        lengths = [c.kwargs["length"] for c in calls]
+        assert lengths == [200, 200, len(gzip.compress(ocr_content))]
+
+    @patch("openfoodfacts_exports.tasks.settings.ENABLE_S3_PUSH", True)
+    def test_upload_new_image_to_s3_images_not_found(self, mocker):
+        """Images return 404, OCR returns 200: only OCR is uploaded."""
+
+        def fake_get_asset_from_url(asset_url, **kwargs):
+            if asset_url.endswith(".jpg"):
+                return AssetDownloadItem(
+                    url=asset_url, response=MagicMock(status_code=404, content=b"")
+                )
+            return AssetDownloadItem(
+                url=asset_url,
+                response=MagicMock(
+                    status_code=200, content='{"ocr": 1}'.encode("utf-8")
+                ),
+            )
+
+        mock_client = mocker.MagicMock()
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_minio_client", return_value=mock_client
+        )
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_asset_from_url",
+            fake_get_asset_from_url,
+        )
+        tasks.upload_new_image_to_s3(
+            image_id="1",
+            barcode="3270160396337",
+            flavor=Flavor.off,
+            environment=Environment.org,
+        )
+
+        assert mock_client.put_object.call_count == 1
+        calls = mock_client.put_object.call_args_list
+        call = calls[0]
+        assert call.kwargs["bucket_name"] == "openfoodfacts-images"
+        assert call.kwargs["object_name"] == "data/327/016/039/6337/1.json.gz"
+
+    @patch("openfoodfacts_exports.tasks.settings.ENABLE_S3_PUSH", True)
+    def test_upload_new_image_to_s3_ocr_not_found(self, mocker):
+        """Images return 200, OCR returns 404: 2 images are uploaded, no OCR upload."""
+        image_content = b"image"
+
+        def fake_get_asset_from_url(asset_url, **kwargs):
+            if asset_url.endswith(".json"):
+                return AssetDownloadItem(
+                    url=asset_url, response=MagicMock(status_code=404, content=b"")
+                )
+            return AssetDownloadItem(
+                url=asset_url,
+                response=MagicMock(status_code=200, content=image_content),
+            )
+
+        mock_client = mocker.MagicMock()
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_minio_client", return_value=mock_client
+        )
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_asset_from_url",
+            fake_get_asset_from_url,
+        )
+        tasks.upload_new_image_to_s3(
+            image_id="1",
+            barcode="3270160396337",
+            flavor=Flavor.off,
+            environment=Environment.org,
+        )
+
+        assert mock_client.put_object.call_count == 2
+        calls = mock_client.put_object.call_args_list
+        assert calls[0].kwargs["object_name"] == "data/327/016/039/6337/1.jpg"
+        assert calls[1].kwargs["object_name"] == "data/327/016/039/6337/1.400.jpg"
+
+    @patch("openfoodfacts_exports.tasks.settings.ENABLE_S3_PUSH", True)
+    def test_upload_new_image_to_s3_response_none(self, mocker):
+        """When AssetDownloadItem.response is None (connection error), skip that
+        asset."""
+
+        def fake_get_asset_from_url(asset_url, **kwargs):
+            return AssetDownloadItem(url=asset_url, response=None)
+
+        mock_client = mocker.MagicMock()
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_minio_client", return_value=mock_client
+        )
+        mocker.patch(
+            "openfoodfacts_exports.tasks.get_asset_from_url",
+            fake_get_asset_from_url,
+        )
+        tasks.upload_new_image_to_s3(
+            image_id="1",
+            barcode="3270160396337",
+            flavor=Flavor.off,
+            environment=Environment.org,
+        )
+
+        # No uploads should happen since all responses are None
+        mock_client.put_object.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -74,6 +74,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 source = { registry = "https://pypi.org/simple" }
@@ -494,10 +503,11 @@ wheels = [
 
 [[package]]
 name = "openfoodfacts-exports"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },
+    { name = "backoff" },
     { name = "duckdb" },
     { name = "huggingface-hub" },
     { name = "minio" },
@@ -520,6 +530,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
     { name = "types-pytz" },
     { name = "types-toml" },
@@ -528,6 +539,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.10.4" },
+    { name = "backoff", specifier = "~=2.2.1" },
     { name = "duckdb", specifier = "==1.1.2" },
     { name = "huggingface-hub", specifier = ">=0.26.2" },
     { name = "minio", specifier = ">=7.2.10" },
@@ -550,6 +562,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = "~=3.15.1" },
     { name = "ruff", specifier = ">=0.7.3" },
     { name = "types-pytz", specifier = ">=2024.2.0.20241003" },
     { name = "types-toml", specifier = ">=0.10.8.20240310" },
@@ -834,6 +847,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945, upload-time = "2024-10-29T20:13:35.363Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949, upload-time = "2024-10-29T20:13:33.215Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 Add a service that listen to Redis product update events, and update
 the AWS S3 image bucket accordingly:

- for new images, upload images (raw, 400px) and OCR result to S3
- for deleted images, delete the image on S3

I'm not sure whether images are deleted when a product is deleted, so I kept it as-it for now.
The weekly script to sync images to S3 (https://github.com/openfoodfacts/openfoodfacts-infrastructure/tree/develop/scripts/ovh3/sync-s3-images) will still be used as a backup in case some image were not synced.
However, it needs to be updated so that it doesn't delete images uploaded between the time of creation of the JSONL dump and the time the process is run.