### PR TITLE
fix: use static.openfoodfacts.org subdomain when syncing images to S3

### DIFF
--- a/openfoodfacts_exports/tasks.py
+++ b/openfoodfacts_exports/tasks.py
@@ -149,6 +149,14 @@ def upload_new_image_to_s3(
             flavor=flavor,
             environment=environment,
         )
+        # Images are not yet available on images.openfoodfacts.org proxy,
+        # so we query the source (static.openfoodfacts.org) directly.
+        if not image_url.startswith("https://images."):
+            raise RuntimeError(
+                f"image_url {image_url} does not start with https://images."
+            )
+        # Replace images subdomain with static subdomain
+        image_url = image_url.replace("https://images.", "https://static.")
         image_asset = get_asset_from_url(asset_url=image_url, error_raise=False)
         image_base_path = _generate_file_path(
             code=barcode, image_id=image_prefix, suffix=".jpg"

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -24,7 +24,10 @@ class TestUploadNewImageToS3:
         ocr_content = '{"ocr": "data"}'.encode("utf-8")
 
         def fake_get_asset_from_url(asset_url, **kwargs):
-            content = ocr_content if asset_url.endswith(".json") else image_content
+            is_ocr = asset_url.endswith(".json")
+            if not is_ocr:
+                assert asset_url.startswith("https://static.")
+            content = ocr_content if is_ocr else image_content
             return AssetDownloadItem(
                 url=asset_url, response=MagicMock(status_code=200, content=content)
             )

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ wheels = [
 
 [[package]]
 name = "openfoodfacts-exports"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Images are often not available on images.openfoodfacts.org.