### PR TITLE
feat: export new product revisions to S3

### DIFF
--- a/openfoodfacts_exports/settings.py
+++ b/openfoodfacts_exports/settings.py
@@ -21,6 +21,9 @@ ENABLE_S3_PUSH = int(os.getenv("ENABLE_S3_PUSH", "0"))
 
 AWS_S3_DATASET_BUCKET = os.getenv("AWS_S3_DATASET_BUCKET", "openfoodfacts-ds")
 AWS_S3_IMAGE_BUCKET = os.getenv("AWS_S3_IMAGE_BUCKET", "openfoodfacts-images")
+AWS_S3_REVISION_BUCKET = os.getenv(
+    "AWS_S3_REVISION_BUCKET", "openfoodfacts-product-revisions"
+)
 
 # Remote Redis where Product Opener publishes product updates in a stream
 REDIS_UPDATE_HOST = os.environ.get("REDIS_UPDATE_HOST", "localhost")

--- a/openfoodfacts_exports/tasks.py
+++ b/openfoodfacts_exports/tasks.py
@@ -3,15 +3,18 @@ import io
 import logging
 from pathlib import Path
 
+import orjson
 import requests
-from openfoodfacts import Environment, Flavor, get_dataset
+from minio import Minio
+from openfoodfacts import APIVersion, Environment, Flavor, get_dataset
+from openfoodfacts.api import API
 from openfoodfacts.dataset import DEFAULT_CACHE_DIR
 from openfoodfacts.images import (
     _generate_file_path,
     generate_image_url,
     generate_json_ocr_url,
 )
-from openfoodfacts.types import DatasetType
+from openfoodfacts.types import DatasetType, JSONType
 from openfoodfacts.utils import (
     download_file,
     get_asset_from_url,
@@ -217,3 +220,134 @@ def delete_image_from_s3(image_id: str, barcode: str) -> None:
             bucket_name=settings.AWS_S3_IMAGE_BUCKET,
             object_name=s3_path,
         )
+
+
+def sync_product_revision(
+    barcode: str, environment: Environment, flavor: Flavor
+) -> None:
+    """Synchronize a product revision to S3.
+
+    This function retrieves the product data from the Open Food Facts API and uploads it
+    to S3.
+
+    Args:
+        barcode: The barcode of the product.
+        environment: The environment to use.
+        flavor: The flavor to use.
+    """
+    api_version = APIVersion.v2
+    api = API(
+        user_agent=settings.USER_AGENT,
+        flavor=flavor,
+        environment=environment,
+        version=api_version,
+    )
+    client = get_minio_client()
+    try:
+        product = api.product.get(code=barcode)
+    except Exception as e:
+        logger.error("Failed to sync product revision for barcode %s: %s", barcode, e)
+        return
+    if product is None:
+        # Product does not exist
+        return
+    else:
+        # Product found
+        upload_revision(
+            minio_client=client,
+            api_version=api_version,
+            barcode=barcode,
+            product=product,
+            set_as_latest=True,
+        )
+
+
+def delete_product_from_s3(barcode: str) -> None:
+    client = get_minio_client()
+    remove_latest_revision(
+        client,
+        APIVersion.v2,
+        barcode,
+    )
+
+
+def remove_latest_revision(minio_client: Minio, api_version: APIVersion, barcode: str):
+    """Remove the latest revision for a product from S3.
+
+    Args:
+        minio_client: The Minio client.
+        api_version: The API version we used when calling the Open Food Facts API.
+        barcode: The barcode of the product.
+    """
+    revision_path = generate_revision_path(api_version, barcode, "latest")
+    logger.info("Removing latest revision for barcode %s at %s", barcode, revision_path)
+    minio_client.remove_object(
+        bucket_name=settings.AWS_S3_REVISION_BUCKET,
+        object_name=revision_path,
+    )
+
+
+def upload_revision(
+    minio_client: Minio,
+    api_version: APIVersion,
+    barcode: str,
+    product: JSONType,
+    set_as_latest: bool = False,
+) -> None:
+    """Upload a product revision to S3.
+
+    Args:
+        minio_client: The Minio client.
+        api_version: The API version we used when calling the Open Food Facts API.
+        barcode: The barcode of the product.
+        product: The product data.
+        set_as_latest: Whether to upload a revision named "latest.json" alongside the
+            regular revision with the same content.
+    """
+    rev = product["rev"]
+    revision_path = generate_revision_path(api_version, barcode, rev)
+    product_bytes = orjson.dumps(product)
+    fp = io.BytesIO(product_bytes)
+    fp.seek(0)
+    logger.info(
+        "Uploading revision %s for barcode %s at %s", rev, barcode, revision_path
+    )
+    minio_client.put_object(
+        bucket_name=settings.AWS_S3_REVISION_BUCKET,
+        object_name=revision_path,
+        data=fp,
+        length=len(product_bytes),
+    )
+    if set_as_latest:
+        logger.info(
+            "Setting revision %s as latest for barcode %s at %s",
+            rev,
+            barcode,
+            revision_path,
+        )
+        fp.seek(0)
+        latest_path = str(Path(revision_path).with_name("latest.json"))
+        minio_client.put_object(
+            bucket_name=settings.AWS_S3_REVISION_BUCKET,
+            object_name=latest_path,
+            data=fp,
+            length=len(product_bytes),
+        )
+
+
+def generate_revision_path(
+    api_version: APIVersion,
+    barcode: str,
+    rev_id: int | str,
+) -> str:
+    """Generate the revision path when uploading product revisions to S3.
+
+    Args:
+        api_version: The API version we used when calling the Open Food Facts API.
+        barcode: The barcode of the product.
+        rev_id: The revision ID.
+
+    Returns:
+        The revision path.
+    """
+    return f"{api_version.value}/{barcode}/{rev_id}.json"

--- a/openfoodfacts_exports/update_listener.py
+++ b/openfoodfacts_exports/update_listener.py
@@ -9,7 +9,12 @@ from redis import Redis
 from redis.exceptions import ConnectionError
 
 from openfoodfacts_exports import settings
-from openfoodfacts_exports.tasks import delete_image_from_s3, upload_new_image_to_s3
+from openfoodfacts_exports.tasks import (
+    delete_image_from_s3,
+    delete_product_from_s3,
+    sync_product_revision,
+    upload_new_image_to_s3,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,23 +36,41 @@ class UpdateListener(BaseUpdateListener):
             logger.warning("Product code is empty or null ('%s'), skipping", event.code)
             return
 
-        action = event.action
-        if action == "deleted":
-            logger.info("Product %s has been deleted", event.code)
-        elif action == "updated":
-            if event.is_image_upload():
-                self.process_image_upload(event)
-            elif event.is_image_deletion():
-                self.process_image_deletion(event)
-
-    def process_image_upload(self, event: ProductUpdateEvent):
-        # A new image was uploaded
-        image_id = event.diffs["uploaded_images"]["add"][0]  # type: ignore
-        logger.info("Image %s was added on product %s", image_id, event.code)
         environment = (
             Environment.org if settings.ENVIRONMENT == "prod" else Environment.net
         )
+        action = event.action
         flavor = Flavor[event.flavor]
+        if action == "deleted":
+            logger.info("Product %s has been deleted", event.code)
+            delete_product_from_s3(barcode=event.code)
+        elif action == "updated":
+            logger.info("Product %s has been updated", event.code)
+            self.process_product_update(event, environment, flavor)
+            if event.is_image_upload():
+                self.process_image_upload(event, environment, flavor)
+            elif event.is_image_deletion():
+                self.process_image_deletion(event)
+
+    def process_product_update(
+        self, event: ProductUpdateEvent, environment: Environment, flavor: Flavor
+    ):
+        logger.info(
+            "Syncing product revision for barcode %s (flavor: %s, environment: %s)",
+            event.code,
+            flavor,
+            environment,
+        )
+        sync_product_revision(
+            barcode=event.code, environment=environment, flavor=flavor
+        )
+
+    def process_image_upload(
+        self, event: ProductUpdateEvent, environment: Environment, flavor: Flavor
+    ):
+        # A new image was uploaded
+        image_id = event.diffs["uploaded_images"]["add"][0]  # type: ignore
+        logger.info("Image %s was added on product %s", image_id, event.code)
 
         # The redis event is sometimes published before Product Opener finishes
         # to process the uploaded image, so we wait 2 seconds before processing

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,7 +1,9 @@
 import gzip
+import json
 from unittest.mock import MagicMock, patch
 
-from openfoodfacts import Environment, Flavor
+import orjson
+from openfoodfacts import APIVersion, Environment, Flavor
 from openfoodfacts.utils import AssetDownloadItem
 
 from openfoodfacts_exports import tasks
@@ -157,3 +159,58 @@ class TestUploadNewImageToS3:
 
         # No uploads should happen since all responses are None
         mock_client.put_object.assert_not_called()
+
+
+class TestUploadRevision:
+    _BARCODE = "3270160396337"
+    _API_VERSION = APIVersion.v2
+
+    def test_upload_revision(self, mocker):
+        mock_client = mocker.MagicMock()
+        product = {"rev": 12, "name": "Test Product"}
+        tasks.upload_revision(
+            mock_client,
+            api_version=self._API_VERSION,
+            barcode=self._BARCODE,
+            product=product,
+        )
+        mock_client.put_object.assert_called_once()
+        assert (
+            mock_client.put_object.call_args.kwargs["bucket_name"]
+            == "openfoodfacts-product-revisions"
+        )
+        assert (
+            mock_client.put_object.call_args.kwargs["object_name"]
+            == f"v2/{self._BARCODE}/12.json"
+        )
+        fp = mock_client.put_object.call_args.kwargs["data"]
+        put_object_product = json.load(fp)
+        assert put_object_product == product
+        assert mock_client.put_object.call_args.kwargs["length"] == len(
+            orjson.dumps(product)
+        )
+
+    def test_upload_revision_set_as_latest(self, mocker):
+        mock_client = mocker.MagicMock()
+        product = {"rev": 12, "name": "Test Product"}
+        tasks.upload_revision(
+            mock_client,
+            api_version=self._API_VERSION,
+            barcode=self._BARCODE,
+            product=product,
+            set_as_latest=True,
+        )
+        assert mock_client.put_object.call_count == 2
+        set_as_latest_call = mock_client.put_object.call_args_list[1]
+        assert (
+            set_as_latest_call.kwargs["bucket_name"]
+            == "openfoodfacts-product-revisions"
+        )
+        assert (
+            set_as_latest_call.kwargs["object_name"]
+            == f"v2/{self._BARCODE}/latest.json"
+        )
+        fp = set_as_latest_call.kwargs["data"]
+        put_object_product = json.load(fp)
+        assert put_object_product == product
+        assert set_as_latest_call.kwargs["length"] == len(orjson.dumps(product))


### PR DESCRIPTION
This PR add live exports of product revisions to AWS S3.
When a product is updated, a new event is published on Redis. We now fetches the latest product version (=revision) and upload it to AWS S3.
This is the first step required to solve #70.