### PR TITLE
feat: add offline historical events generator

### DIFF
--- a/openfoodfacts_exports/exports/historical_events.py
+++ b/openfoodfacts_exports/exports/historical_events.py
@@ -1,0 +1,199 @@
+"""Generate historical product events from product revisions.
+
+This module turns product revisions into a flat, self-sufficient stream of
+field-level change events. The stream is meant to be published as a public
+JSONL dump (`{PREFIX}_historical_events.jsonl.gz`) and analysed offline
+(duckdb/parquet), to study how products evolve over time (recipe
+reformulation, Nutri-Score evolution, ...).
+
+Each output row describes a single field change at a given revision::
+
+    {"id": "{code}_{rev}", "code": "...", "rev_id": 252, "timestamp": ...,
+     "product_type": "food", "comment": "...", "field": "brands",
+     "previous": "Nestlé", "current": "Nestlé,Nescafé", "action": "change"}
+
+Two identifiers coexist on purpose:
+
+- ``rev_id`` is the per-product revision number (unique within a product).
+- ``id`` is ``{code}_{rev}``, a globally unique key.
+
+Revision metadata (``timestamp``, ``product_type``, ``comment``) is
+denormalised onto every row, so the dump can be consumed without any join.
+
+This module is intentionally pure and offline: it does not read from S3, the
+Redis stream or the API. Those integrations (live capture and backlog
+backfill) are wired separately on top of these functions.
+"""
+
+import gzip
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import orjson
+from openfoodfacts.types import JSONType
+
+# Per-field change operations, as found in Product Opener revision diffs.
+ADD = "add"
+CHANGE = "change"
+DELETE = "delete"
+ACTIONS = (ADD, CHANGE, DELETE)
+
+
+@dataclass(frozen=True)
+class FieldChange:
+    """A single field change extracted from a revision diff."""
+
+    field: str
+    action: str  # one of ACTIONS
+
+
+@dataclass(frozen=True)
+class RevisionInfo:
+    """Metadata about a single product revision.
+
+    These fields are denormalised onto every event row generated for the
+    revision.
+    """
+
+    code: str
+    rev_id: int
+    timestamp: int
+    product_type: str | None = None
+    comment: str | None = None
+
+    @property
+    def id(self) -> str:
+        """Globally unique revision key, in the form ``{code}_{rev_id}``."""
+        return f"{self.code}_{self.rev_id}"
+
+
+def flatten_diffs(diffs: JSONType | None) -> list[FieldChange]:
+    """Flatten a Product Opener revision diff into a list of field changes.
+
+    Product Opener groups changes by category (``fields``, ``nutriments``,
+    ``packagings``, ...) and then by operation (``add`` / ``change`` /
+    ``delete``)::
+
+        {"fields": {"change": ["brands"], "add": ["labels"]},
+         "nutriments": {"change": ["energy"]}}
+
+    We deliberately drop the category split to keep the output flat, and
+    return one :class:`FieldChange` per (field, action) pair. Duplicate pairs
+    are collapsed, and unknown operations are ignored.
+
+    Args:
+        diffs: The revision diff, or ``None`` when unavailable.
+
+    Returns:
+        The flattened list of field changes, in a deterministic order.
+    """
+    if not diffs:
+        return []
+
+    changes: list[FieldChange] = []
+    seen: set[tuple[str, str]] = set()
+    for category_value in diffs.values():
+        if not isinstance(category_value, dict):
+            continue
+        for action, fields in category_value.items():
+            if action not in ACTIONS or not fields:
+                continue
+            for field in fields:
+                key = (field, action)
+                if key not in seen:
+                    seen.add(key)
+                    changes.append(FieldChange(field=field, action=action))
+    return changes
+
+
+def resolve_field_value(product: JSONType | None, field: str) -> Any:
+    """Look up a (possibly dotted) field path in a product revision.
+
+    Field names may be nested paths such as
+    ``packaging.as_sold.100g.nutrients.energy.value``. The path is resolved by
+    walking successive dictionary keys.
+
+    Args:
+        product: The product revision, or ``None`` when the revision does not
+            exist (e.g. before creation).
+        field: The field name or dotted path to resolve.
+
+    Returns:
+        The resolved value, or ``None`` if the product is ``None`` or the path
+        is missing.
+    """
+    if product is None:
+        return None
+
+    value: Any = product
+    for part in field.split("."):
+        if isinstance(value, dict) and part in value:
+            value = value[part]
+        else:
+            return None
+    return value
+
+
+def generate_events(
+    revision: RevisionInfo,
+    diffs: JSONType | None,
+    previous_product: JSONType | None,
+    current_product: JSONType | None,
+) -> list[JSONType]:
+    """Generate the historical event rows for a single revision.
+
+    For each changed field, the previous value is read from the previous
+    revision and the current value from the current revision. On an ``add``
+    there is no previous value, and on a ``delete`` there is no current value,
+    so the corresponding side is left as ``None``.
+
+    Args:
+        revision: Metadata about the current revision.
+        diffs: The revision diff listing the changed fields.
+        previous_product: The previous revision (``rev_id - 1``), or ``None``.
+        current_product: The current revision (``rev_id``).
+
+    Returns:
+        One row per changed field, ready to be serialised as JSONL.
+    """
+    events: list[JSONType] = []
+    for change in flatten_diffs(diffs):
+        previous_value = (
+            None
+            if change.action == ADD
+            else resolve_field_value(previous_product, change.field)
+        )
+        current_value = (
+            None
+            if change.action == DELETE
+            else resolve_field_value(current_product, change.field)
+        )
+        events.append(
+            {
+                "id": revision.id,
+                "code": revision.code,
+                "rev_id": revision.rev_id,
+                "timestamp": revision.timestamp,
+                "product_type": revision.product_type,
+                "comment": revision.comment,
+                "field": change.field,
+                "previous": previous_value,
+                "current": current_value,
+                "action": change.action,
+            }
+        )
+    return events
+
+
+def write_events_jsonl_gz(events: Iterable[JSONType], output_path: Path) -> None:
+    """Write event rows to a gzipped JSONL file.
+
+    Args:
+        events: The event rows to write.
+        output_path: The destination ``.jsonl.gz`` file.
+    """
+    with gzip.open(output_path, "wb") as fp:
+        for event in events:
+            fp.write(orjson.dumps(event))
+            fp.write(b"\n")

--- a/tests/unit/exports/test_historical_events.py
+++ b/tests/unit/exports/test_historical_events.py
@@ -1,0 +1,165 @@
+import gzip
+
+import orjson
+
+from openfoodfacts_exports.exports.historical_events import (
+    FieldChange,
+    RevisionInfo,
+    flatten_diffs,
+    generate_events,
+    resolve_field_value,
+    write_events_jsonl_gz,
+)
+
+
+class TestFlattenDiffs:
+    def test_none_and_empty(self):
+        """A missing or empty diff yields no field change."""
+        assert flatten_diffs(None) == []
+        assert flatten_diffs({}) == []
+
+    def test_drops_the_category_split(self):
+        """Changes from every category are merged into a single flat list."""
+        diffs = {
+            "fields": {"change": ["brands"]},
+            "nutriments": {"change": ["energy"]},
+        }
+        assert flatten_diffs(diffs) == [
+            FieldChange(field="brands", action="change"),
+            FieldChange(field="energy", action="change"),
+        ]
+
+    def test_keeps_every_operation(self):
+        """add, change and delete operations are all preserved."""
+        diffs = {"fields": {"add": ["labels"], "change": ["brands"], "delete": ["url"]}}
+        assert flatten_diffs(diffs) == [
+            FieldChange(field="labels", action="add"),
+            FieldChange(field="brands", action="change"),
+            FieldChange(field="url", action="delete"),
+        ]
+
+    def test_ignores_unknown_operations_and_empty_lists(self):
+        """Unknown operation keys and empty field lists are skipped."""
+        diffs = {"fields": {"change": [], "unknown": ["brands"]}}
+        assert flatten_diffs(diffs) == []
+
+    def test_deduplicates_field_action_pairs(self):
+        """The same (field, action) pair appearing twice is collapsed once."""
+        diffs = {
+            "fields": {"change": ["brands"]},
+            "nutriments": {"change": ["brands"]},
+        }
+        assert flatten_diffs(diffs) == [FieldChange(field="brands", action="change")]
+
+
+class TestResolveFieldValue:
+    def test_top_level_field(self):
+        assert resolve_field_value({"brands": "Nestlé"}, "brands") == "Nestlé"
+
+    def test_nested_dotted_path(self):
+        product = {"nutriments": {"energy": {"value": 42}}}
+        assert resolve_field_value(product, "nutriments.energy.value") == 42
+
+    def test_missing_field_returns_none(self):
+        assert resolve_field_value({"brands": "Nestlé"}, "labels") is None
+
+    def test_missing_nested_path_returns_none(self):
+        assert resolve_field_value({"nutriments": {}}, "nutriments.energy") is None
+
+    def test_none_product_returns_none(self):
+        assert resolve_field_value(None, "brands") is None
+
+    def test_non_dict_along_path_returns_none(self):
+        assert resolve_field_value({"brands": "Nestlé"}, "brands.value") is None
+
+
+class TestGenerateEvents:
+    _REVISION = RevisionInfo(
+        code="7622210449283",
+        rev_id=252,
+        timestamp=1540932933,
+        product_type="food",
+        comment="Updated brands",
+    )
+
+    def test_change_carries_previous_and_current(self):
+        """A change reads the previous value and the current value."""
+        events = generate_events(
+            self._REVISION,
+            diffs={"fields": {"change": ["brands"]}},
+            previous_product={"brands": "Nestlé"},
+            current_product={"brands": "Nestlé,Nescafé"},
+        )
+        assert events == [
+            {
+                "id": "7622210449283_252",
+                "code": "7622210449283",
+                "rev_id": 252,
+                "timestamp": 1540932933,
+                "product_type": "food",
+                "comment": "Updated brands",
+                "field": "brands",
+                "previous": "Nestlé",
+                "current": "Nestlé,Nescafé",
+                "action": "change",
+            }
+        ]
+
+    def test_add_has_no_previous_value(self):
+        """An add leaves the previous value empty even if one is resolvable."""
+        events = generate_events(
+            self._REVISION,
+            diffs={"fields": {"add": ["labels"]}},
+            previous_product={"labels": "should be ignored"},
+            current_product={"labels": "Organic"},
+        )
+        assert events[0]["previous"] is None
+        assert events[0]["current"] == "Organic"
+        assert events[0]["action"] == "add"
+
+    def test_delete_has_no_current_value(self):
+        """A delete leaves the current value empty even if one is resolvable."""
+        events = generate_events(
+            self._REVISION,
+            diffs={"fields": {"delete": ["url"]}},
+            previous_product={"url": "http://example.org"},
+            current_product={"url": "should be ignored"},
+        )
+        assert events[0]["previous"] == "http://example.org"
+        assert events[0]["current"] is None
+        assert events[0]["action"] == "delete"
+
+    def test_nested_field_path(self):
+        """Nested dotted paths are resolved on both revisions."""
+        events = generate_events(
+            self._REVISION,
+            diffs={"nutriments": {"change": ["nutriments.energy.value"]}},
+            previous_product={"nutriments": {"energy": {"value": 42}}},
+            current_product={"nutriments": {"energy": {"value": 50}}},
+        )
+        assert events[0]["previous"] == 42
+        assert events[0]["current"] == 50
+
+    def test_no_diff_yields_no_event(self):
+        events = generate_events(
+            self._REVISION,
+            diffs=None,
+            previous_product={"brands": "Nestlé"},
+            current_product={"brands": "Nestlé"},
+        )
+        assert events == []
+
+
+class TestWriteEventsJsonlGz:
+    def test_round_trip(self, tmp_path):
+        """Written rows can be read back as gzipped JSONL, one object per line."""
+        events = [
+            {"id": "1_1", "field": "brands", "action": "add"},
+            {"id": "1_2", "field": "labels", "action": "change"},
+        ]
+        output_path = tmp_path / "off_historical_events.jsonl.gz"
+        write_events_jsonl_gz(events, output_path)
+
+        with gzip.open(output_path, "rb") as fp:
+            lines = fp.read().splitlines()
+        assert [orjson.loads(line) for line in lines] == events


### PR DESCRIPTION
Turn product revisions into a flat stream of field-level change events, meant to be published as a public JSONL dump and analysed offline.

Each row describes one field change at a revision, with the previous and current values and the revision metadata (timestamp, product_type, comment) denormalised onto it, so the dump needs no join. The generator is pure and offline; live capture and backlog backfill are wired separately on top.

### What

This is a first, self-contained step towards the historical_events dump discussed in #70. It adds a pure, offline generator and its tests, with no S3, Redis or API wiring yet, so it can be reviewed on its own.

New module openfoodfacts_exports/exports/historical_events.py:

- flatten_diffs(): flattens a Product Opener revision diff (grouped by category, then by add / change / delete) into a flat list of field changes. The category split (fields / nutriments / ...) is dropped to keep the output simple, and duplicate pairs are collapsed.
- resolve_field_value(): resolves a field on a revision, including nested dotted paths such as nutriments.energy.value.
- generate_events(): produces one row per changed field. On an add there is no previous value, on a delete there is no current value.
- write_events_jsonl_gz(): writes the rows as a gzipped JSONL file.

A row looks like this:

{"id": "7622210449283_252", "code": "7622210449283", "rev_id": 252, "timestamp": 1540932933, "product_type": "food", "comment": "...", "field": "brands", "previous": "Nestlé", "current": "Nestlé,Nescafé", "action": "change"}

Design choices, following the discussion in #70:

- Single, self-sufficient events file. The revision metadata is denormalised onto every row, so no compeded to read the dump.
- Two identifiers: rev_id is the per-product revision number, id = {code}_{rev} is a globally unique key.
- Contributor identifiers are not part of the schema, to respect the right to be forgotten.

Tests: 17 unit tests in tests/unit/exports/test_historical_events.py, covering the diff flattening, thethe row generation (change / add / delete, missing paths, JSONL round-trip). No new dependency is
introduced.

Out of scope here, planned as follow-ups:

- Live capture: call the generator from the Redis update listener and store the derived rows on S3, nex
- Nightly publication of ${PREFIX}_historical_events.jsonl.gz on s3://openfoodfacts-ds/.
- Backlog backfill from the products/ history (pending a decision on a one-off backend run reusing Prodrsus a backfill through the API, because of schema differences between old revisions).

### Part of

- #70