### PR TITLE
Feat/historical events pipeline

### DIFF
--- a/openfoodfacts_exports/main.py
+++ b/openfoodfacts_exports/main.py
@@ -79,3 +79,19 @@ def backfill_historical_events(products_dir: Path, output_path: Path) -> None:
     get_logger()
     init_sentry()
     backfill_historical_events_to_file(products_dir, output_path)
+
+
+@app.command()
+def publish_historical_events() -> None:
+    """Concatenate stored historical events into the public dump and push it to S3."""
+    from openfoodfacts.utils import get_logger
+
+    from openfoodfacts_exports.tasks.historical_events import (
+        publish_historical_events_dump,
+    )
+    from openfoodfacts_exports.utils import init_sentry
+
+    # configure root logger
+    get_logger()
+    init_sentry()
+    publish_historical_events_dump()

--- a/openfoodfacts_exports/main.py
+++ b/openfoodfacts_exports/main.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import typer
 
 from openfoodfacts_exports.types import ExportFlavor
@@ -61,3 +63,19 @@ def launch_export(flavor: ExportFlavor) -> None:
     get_logger()
     init_sentry()
     export_job(flavor)
+
+
+@app.command()
+def backfill_historical_events(products_dir: Path, output_path: Path) -> None:
+    """Generate the historical events dump from a bundled products/ directory."""
+    from openfoodfacts.utils import get_logger
+
+    from openfoodfacts_exports.tasks.historical_events import (
+        backfill_historical_events_to_file,
+    )
+    from openfoodfacts_exports.utils import init_sentry
+
+    # configure root logger
+    get_logger()
+    init_sentry()
+    backfill_historical_events_to_file(products_dir, output_path)

--- a/openfoodfacts_exports/scheduler.py
+++ b/openfoodfacts_exports/scheduler.py
@@ -7,6 +7,7 @@ from openfoodfacts.utils import get_logger
 from sentry_sdk import capture_exception
 
 from openfoodfacts_exports.tasks import export_job
+from openfoodfacts_exports.tasks.historical_events import publish_historical_events_dump
 from openfoodfacts_exports.types import ExportFlavor
 from openfoodfacts_exports.workers.queues import high_queue
 
@@ -31,6 +32,11 @@ def export_datasets() -> None:
         high_queue.enqueue(export_job, flavor, job_timeout="1h", result_ttl=0)
 
 
+def export_historical_events() -> None:
+    logger.info("Enqueueing historical events dump export…")
+    high_queue.enqueue(publish_historical_events_dump, job_timeout="3h", result_ttl=0)
+
+
 # The scheduler is responsible for scheduling periodic work such as DB dump
 # generation
 def run() -> None:
@@ -39,6 +45,9 @@ def run() -> None:
     scheduler.add_executor(ThreadPoolExecutor(10))
     scheduler.add_jobstore(MemoryJobStore())
     scheduler.add_job(export_datasets, "cron", hour=16, minute=0, max_instances=1)
+    scheduler.add_job(
+        export_historical_events, "cron", hour=17, minute=0, max_instances=1
+    )
     scheduler.add_listener(exception_listener, EVENT_JOB_ERROR)
     logger.info("Starting scheduler")
     scheduler.start()

--- a/openfoodfacts_exports/tasks/historical_events.py
+++ b/openfoodfacts_exports/tasks/historical_events.py
@@ -1,5 +1,8 @@
+import gzip
 import io
 import logging
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Iterator
 
@@ -16,12 +19,17 @@ from openfoodfacts_exports.exports.historical_events import (
     write_events_jsonl_gz,
 )
 from openfoodfacts_exports.tasks.revisions import strip_product_from_user_ids
+from openfoodfacts_exports.utils import get_minio_client
 
 logger = logging.getLogger(__name__)
 
 # Derived event rows are stored under this prefix in the revision bucket, next to the
 # raw revision snapshots. The nightly export concatenates them into the public dump.
 HISTORICAL_EVENTS_PREFIX = "historical_events"
+
+# Public dump published to the dataset bucket, next to the other exports.
+HISTORICAL_EVENTS_DUMP_FILENAME = "openfoodfacts_historical_events.jsonl.gz"
+HISTORICAL_EVENTS_DUMP_PATH = settings.DATASET_DIR / HISTORICAL_EVENTS_DUMP_FILENAME
 
 
 def generate_events_path(api_version: APIVersion, barcode: str, rev_id: int) -> str:
@@ -191,3 +199,63 @@ def _read_json(path: Path) -> JSONType | None:
         return orjson.loads(path.read_bytes())
     except FileNotFoundError:
         return None
+
+
+def publish_historical_events_dump() -> None:
+    """Publish the public historical events dump to the dataset bucket.
+
+    The per-revision event rows stored under the ``historical_events/`` prefix in the
+    revision bucket are concatenated into a single gzipped JSONL file, which is then
+    pushed to ``s3://openfoodfacts-ds/`` next to the other exports. This is the job run
+    nightly by the scheduler.
+    """
+    minio_client = get_minio_client()
+    generate_historical_events_dump(minio_client, HISTORICAL_EVENTS_DUMP_PATH)
+
+    if settings.ENABLE_S3_PUSH:
+        logger.info("Uploading historical events dump to S3")
+        minio_client.fput_object(
+            settings.AWS_S3_DATASET_BUCKET,
+            HISTORICAL_EVENTS_DUMP_FILENAME,
+            file_path=str(HISTORICAL_EVENTS_DUMP_PATH),
+        )
+        logger.info("Historical events dump uploaded to S3")
+    else:
+        logger.info("S3 push is disabled, skipping upload of historical events dump")
+
+
+def generate_historical_events_dump(minio_client: Minio, output_path: Path) -> None:
+    """Concatenate the stored event rows into a single gzipped JSONL file.
+
+    Each stored object is already newline-terminated JSONL, so the objects are simply
+    streamed one after another into the gzipped output. The file is written to a
+    temporary location first and moved into place, so consumers never see a partial
+    dump.
+
+    Args:
+        minio_client: The Minio client.
+        output_path: The destination ``.jsonl.gz`` file.
+    """
+    objects = minio_client.list_objects(
+        settings.AWS_S3_REVISION_BUCKET,
+        prefix=f"{HISTORICAL_EVENTS_PREFIX}/",
+        recursive=True,
+    )
+    count = 0
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / HISTORICAL_EVENTS_DUMP_FILENAME
+        with gzip.open(tmp_path, "wb") as fp:
+            for obj in objects:
+                response = minio_client.get_object(
+                    settings.AWS_S3_REVISION_BUCKET, obj.object_name
+                )
+                try:
+                    fp.write(response.read())
+                finally:
+                    response.close()
+                    response.release_conn()
+                count += 1
+        shutil.move(tmp_path, output_path)
+    logger.info(
+        "Concatenated %d historical event object(s) into %s", count, output_path
+    )

--- a/openfoodfacts_exports/tasks/historical_events.py
+++ b/openfoodfacts_exports/tasks/historical_events.py
@@ -1,0 +1,92 @@
+import io
+import logging
+
+import orjson
+from minio import Minio
+from openfoodfacts import APIVersion
+from openfoodfacts.redis import ProductUpdateEvent
+from openfoodfacts.types import JSONType
+
+from openfoodfacts_exports import settings
+from openfoodfacts_exports.exports.historical_events import (
+    RevisionInfo,
+    generate_events,
+)
+
+logger = logging.getLogger(__name__)
+
+# Derived event rows are stored under this prefix in the revision bucket, next to the
+# raw revision snapshots. The nightly export concatenates them into the public dump.
+HISTORICAL_EVENTS_PREFIX = "historical_events"
+
+
+def generate_events_path(api_version: APIVersion, barcode: str, rev_id: int) -> str:
+    """Generate the S3 path of the historical events derived from a revision.
+
+    Args:
+        api_version: The API version used when the revision was stored.
+        barcode: The barcode of the product.
+        rev_id: The revision ID.
+
+    Returns:
+        The S3 object path of the derived event rows.
+    """
+    return f"{HISTORICAL_EVENTS_PREFIX}/{api_version.value}/{barcode}/{rev_id}.jsonl"
+
+
+def store_revision_events(
+    minio_client: Minio,
+    api_version: APIVersion,
+    event: ProductUpdateEvent,
+    previous_product: JSONType | None,
+    current_product: JSONType,
+) -> None:
+    """Generate and store the historical events for a single product update.
+
+    The event rows are computed from the update diff and the previous/current
+    revisions, then uploaded to S3 as JSONL, next to the revision snapshots. Both
+    revisions are already stripped of user IDs, so no contributor data is stored.
+
+    Args:
+        minio_client: The Minio client.
+        api_version: The API version used when the revision was stored.
+        event: The product update event from the Redis stream.
+        previous_product: The previous revision (``rev - 1``), or ``None``.
+        current_product: The current revision, as uploaded by the sync.
+    """
+    rev_id = current_product.get("rev")
+    if rev_id is None:
+        logger.warning(
+            "Product %s has no revision number, skipping historical events", event.code
+        )
+        return
+
+    revision = RevisionInfo(
+        code=event.code,
+        rev_id=rev_id,
+        timestamp=int(event.timestamp.timestamp()),
+        product_type=event.product_type,
+        comment=event.comment,
+    )
+    events = generate_events(revision, event.diffs, previous_product, current_product)
+    if not events:
+        logger.debug(
+            "No historical event for product %s revision %s", event.code, rev_id
+        )
+        return
+
+    events_bytes = b"".join(orjson.dumps(row) + b"\n" for row in events)
+    object_name = generate_events_path(api_version, event.code, rev_id)
+    logger.info(
+        "Storing %d historical event(s) for product %s at %s",
+        len(events),
+        event.code,
+        object_name,
+    )
+    minio_client.put_object(
+        bucket_name=settings.AWS_S3_REVISION_BUCKET,
+        object_name=object_name,
+        data=io.BytesIO(events_bytes),
+        length=len(events_bytes),
+        content_type="application/x-ndjson",
+    )

--- a/openfoodfacts_exports/tasks/historical_events.py
+++ b/openfoodfacts_exports/tasks/historical_events.py
@@ -1,5 +1,7 @@
 import io
 import logging
+from pathlib import Path
+from typing import Iterator
 
 import orjson
 from minio import Minio
@@ -11,7 +13,9 @@ from openfoodfacts_exports import settings
 from openfoodfacts_exports.exports.historical_events import (
     RevisionInfo,
     generate_events,
+    write_events_jsonl_gz,
 )
+from openfoodfacts_exports.tasks.revisions import strip_product_from_user_ids
 
 logger = logging.getLogger(__name__)
 
@@ -90,3 +94,100 @@ def store_revision_events(
         length=len(events_bytes),
         content_type="application/x-ndjson",
     )
+
+
+def backfill_historical_events_to_file(products_dir: Path, output_path: Path) -> None:
+    """Generate the whole historical events backlog into a gzipped JSONL file.
+
+    This is the one-off backfill: it rebuilds the historical events for every product
+    revision from a bundled ``products/`` directory, so the dump is not limited to
+    updates captured live from the Redis stream.
+
+    Args:
+        products_dir: The root of the bundled ``products/`` directory.
+        output_path: The destination ``.jsonl.gz`` file.
+    """
+    logger.info("Backfilling historical events from %s", products_dir)
+    write_events_jsonl_gz(iter_backfill_events(products_dir), output_path)
+    logger.info("Backfill written to %s", output_path)
+
+
+def iter_backfill_events(products_dir: Path) -> Iterator[JSONType]:
+    """Generate historical events for the whole backlog from a ``products/`` bundle.
+
+    The bundle is the on-disk Product Opener ``products/`` directory, in JSON format
+    (after the STO to JSON migration). Each product folder holds one snapshot file per
+    revision (``{rev}.json``) and a ``changes.json`` file with one record per revision
+    (``rev``, ``t``, ``comment``, ``diffs``, ...).
+
+    For each revision, the changed fields come from the ``changes.json`` diff, and the
+    previous/current values are read from the ``{rev - 1}.json`` and ``{rev}.json``
+    snapshots. Both snapshots are stripped of user IDs, so no contributor data is
+    emitted. This is fully offline: no S3, Redis or API access.
+
+    Args:
+        products_dir: The root of the bundled ``products/`` directory.
+
+    Yields:
+        One event row per changed field, across every product and revision.
+    """
+    for changes_path in sorted(products_dir.rglob("changes.json")):
+        product_dir = changes_path.parent
+        changes = _read_json(changes_path)
+        if not isinstance(changes, list):
+            logger.warning("Unexpected changes file, skipping: %s", changes_path)
+            continue
+        for record in sorted(changes, key=lambda item: int(item.get("rev", 0))):
+            try:
+                yield from _generate_revision_events(product_dir, record)
+            except Exception:
+                logger.exception(
+                    "Failed to process revision %s in %s",
+                    record.get("rev"),
+                    product_dir,
+                )
+
+
+def _generate_revision_events(product_dir: Path, record: JSONType) -> list[JSONType]:
+    """Generate the event rows for a single revision of the backlog."""
+    rev = record.get("rev")
+    if rev is None:
+        logger.warning("Change record without a revision number in %s", product_dir)
+        return []
+
+    current_product = _read_snapshot(product_dir, rev)
+    if current_product is None:
+        logger.warning("Missing snapshot for revision %s in %s", rev, product_dir)
+        return []
+
+    # The previous snapshot may be absent when the product history is truncated
+    # (the oldest revisions are not always kept on disk).
+    previous_product = _read_snapshot(product_dir, int(rev) - 1)
+
+    current_product = strip_product_from_user_ids(current_product)
+    if previous_product is not None:
+        previous_product = strip_product_from_user_ids(previous_product)
+
+    revision = RevisionInfo(
+        code=current_product["code"],
+        rev_id=rev,
+        timestamp=record["t"],
+        product_type=current_product.get("product_type"),
+        comment=record.get("comment"),
+    )
+    return generate_events(
+        revision, record.get("diffs"), previous_product, current_product
+    )
+
+
+def _read_snapshot(product_dir: Path, rev: int | str) -> JSONType | None:
+    """Read a revision snapshot from a product folder, or ``None`` if absent."""
+    return _read_json(product_dir / f"{rev}.json")
+
+
+def _read_json(path: Path) -> JSONType | None:
+    """Read and parse a JSON file, or return ``None`` if it does not exist."""
+    try:
+        return orjson.loads(path.read_bytes())
+    except FileNotFoundError:
+        return None

--- a/openfoodfacts_exports/tasks/revisions.py
+++ b/openfoodfacts_exports/tasks/revisions.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import orjson
 from minio import Minio
+from minio.error import S3Error
 from openfoodfacts import APIVersion, Environment, Flavor
 from openfoodfacts.api import API
 from openfoodfacts.types import JSONType
@@ -59,7 +60,7 @@ def strip_product_from_user_ids(product: JSONType) -> JSONType:
 
 def sync_product_revision(
     barcode: str, environment: Environment, flavor: Flavor
-) -> None:
+) -> JSONType | None:
     """Synchronize a product revision to S3.
 
     This function retrieves the product data from the Open Food Facts API and uploads it
@@ -69,6 +70,10 @@ def sync_product_revision(
         barcode: The barcode of the product.
         environment: The environment to use.
         flavor: The flavor to use.
+
+    Returns:
+        The uploaded product revision (stripped of user IDs), or ``None`` if the product
+        could not be fetched or does not exist.
     """
     api_version = APIVersion.v2
     api = API(
@@ -82,10 +87,10 @@ def sync_product_revision(
         product = api.product.get(code=barcode)
     except Exception as e:
         logger.error("Failed to sync product revision for barcode %s: %s", barcode, e)
-        return
+        return None
     if product is None:
         # Product does not exist
-        return
+        return None
     else:
         product = strip_product_from_user_ids(product)
         # Product found
@@ -96,6 +101,7 @@ def sync_product_revision(
             product=product,
             set_as_latest=True,
         )
+        return product
 
 
 def delete_product_from_s3(barcode: str) -> None:
@@ -189,3 +195,37 @@ def generate_revision_path(
         The revision path.
     """
     return f"{api_version.value}/{barcode}/{rev_id}.json"
+
+
+def get_revision(
+    minio_client: Minio,
+    api_version: APIVersion,
+    barcode: str,
+    rev_id: int | str,
+) -> JSONType | None:
+    """Retrieve a product revision from S3.
+
+    Args:
+        minio_client: The Minio client.
+        api_version: The API version used when the revision was stored.
+        barcode: The barcode of the product.
+        rev_id: The revision ID, or ``"latest"`` for the latest revision.
+
+    Returns:
+        The product revision, or ``None`` if it does not exist on S3.
+    """
+    object_name = generate_revision_path(api_version, barcode, rev_id)
+    try:
+        response = minio_client.get_object(
+            bucket_name=settings.AWS_S3_REVISION_BUCKET,
+            object_name=object_name,
+        )
+    except S3Error as e:
+        if e.code == "NoSuchKey":
+            return None
+        raise
+    try:
+        return orjson.loads(response.read())
+    finally:
+        response.close()
+        response.release_conn()

--- a/openfoodfacts_exports/update_listener.py
+++ b/openfoodfacts_exports/update_listener.py
@@ -2,21 +2,24 @@ import logging
 import time
 
 import backoff
-from openfoodfacts import Environment, Flavor
+from openfoodfacts import APIVersion, Environment, Flavor
 from openfoodfacts.redis import ProductUpdateEvent
 from openfoodfacts.redis import UpdateListener as BaseUpdateListener
 from redis import Redis
 from redis.exceptions import ConnectionError
 
 from openfoodfacts_exports import settings
+from openfoodfacts_exports.tasks.historical_events import store_revision_events
 from openfoodfacts_exports.tasks.images import (
     delete_image_from_s3,
     upload_new_image_to_s3,
 )
 from openfoodfacts_exports.tasks.revisions import (
     delete_product_from_s3,
+    get_revision,
     sync_product_revision,
 )
+from openfoodfacts_exports.utils import get_minio_client
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +73,29 @@ class UpdateListener(BaseUpdateListener):
             flavor,
             environment,
         )
-        sync_product_revision(
+        minio_client = get_minio_client()
+        # Read the previous revision (latest.json) before sync_product_revision
+        # overwrites it, so we can compute the field-level diff against it.
+        previous_product = get_revision(
+            minio_client, APIVersion.v2, event.code, "latest"
+        )
+        current_product = sync_product_revision(
             barcode=event.code, environment=environment, flavor=flavor
         )
+        if current_product is not None:
+            # A diff failure must never break the revision capture above.
+            try:
+                store_revision_events(
+                    minio_client,
+                    APIVersion.v2,
+                    event,
+                    previous_product,
+                    current_product,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to store historical events for product %s", event.code
+                )
 
     def process_image_upload(
         self, event: ProductUpdateEvent, environment: Environment, flavor: Flavor

--- a/tests/unit/tasks/test_historical_events.py
+++ b/tests/unit/tasks/test_historical_events.py
@@ -1,0 +1,100 @@
+import datetime
+from types import SimpleNamespace
+
+import orjson
+from openfoodfacts import APIVersion
+
+from openfoodfacts_exports.tasks.historical_events import (
+    generate_events_path,
+    store_revision_events,
+)
+
+
+def _make_event(**overrides):
+    """Build a minimal product update event with the attributes we read."""
+    defaults = {
+        "code": "7622210449283",
+        "timestamp": datetime.datetime(
+            2018, 10, 30, 20, 55, 33, tzinfo=datetime.timezone.utc
+        ),
+        "product_type": "food",
+        "comment": "Updated brands",
+        "diffs": {"fields": {"change": ["brands"]}},
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_generate_events_path():
+    assert (
+        generate_events_path(APIVersion.v2, "7622210449283", 252)
+        == "historical_events/v2/7622210449283/252.jsonl"
+    )
+
+
+class TestStoreRevisionEvents:
+    def test_stores_event_rows(self, mocker):
+        """A field change is stored as a JSONL object in the revision bucket."""
+        mock_client = mocker.MagicMock()
+        event = _make_event()
+
+        store_revision_events(
+            mock_client,
+            APIVersion.v2,
+            event,
+            previous_product={"rev": 251, "brands": "Nestlé"},
+            current_product={"rev": 252, "brands": "Nestlé,Nescafé"},
+        )
+
+        mock_client.put_object.assert_called_once()
+        kwargs = mock_client.put_object.call_args.kwargs
+        assert kwargs["bucket_name"] == "openfoodfacts-product-revisions"
+        assert kwargs["object_name"] == "historical_events/v2/7622210449283/252.jsonl"
+        assert kwargs["content_type"] == "application/x-ndjson"
+        body = kwargs["data"].read()
+        assert kwargs["length"] == len(body)
+        rows = [orjson.loads(line) for line in body.splitlines()]
+        assert rows == [
+            {
+                "id": "7622210449283_252",
+                "code": "7622210449283",
+                "rev_id": 252,
+                "timestamp": int(event.timestamp.timestamp()),
+                "product_type": "food",
+                "comment": "Updated brands",
+                "field": "brands",
+                "previous": "Nestlé",
+                "current": "Nestlé,Nescafé",
+                "action": "change",
+            }
+        ]
+
+    def test_no_event_is_not_stored(self, mocker):
+        """When the diff yields no field change, nothing is uploaded."""
+        mock_client = mocker.MagicMock()
+        event = _make_event(diffs=None)
+
+        store_revision_events(
+            mock_client,
+            APIVersion.v2,
+            event,
+            previous_product=None,
+            current_product={"rev": 252},
+        )
+
+        mock_client.put_object.assert_not_called()
+
+    def test_missing_rev_is_not_stored(self, mocker):
+        """A current product without a revision number is skipped."""
+        mock_client = mocker.MagicMock()
+        event = _make_event()
+
+        store_revision_events(
+            mock_client,
+            APIVersion.v2,
+            event,
+            previous_product=None,
+            current_product={"brands": "Nestlé"},
+        )
+
+        mock_client.put_object.assert_not_called()

--- a/tests/unit/tasks/test_historical_events.py
+++ b/tests/unit/tasks/test_historical_events.py
@@ -1,13 +1,26 @@
 import datetime
+import gzip
 from types import SimpleNamespace
 
 import orjson
 from openfoodfacts import APIVersion
 
 from openfoodfacts_exports.tasks.historical_events import (
+    backfill_historical_events_to_file,
     generate_events_path,
+    iter_backfill_events,
     store_revision_events,
 )
+
+
+def _make_product(products_dir, rel_dir, changes, snapshots):
+    """Create a fake Product Opener product folder inside a products/ bundle."""
+    product_dir = products_dir / rel_dir
+    product_dir.mkdir(parents=True)
+    (product_dir / "changes.json").write_bytes(orjson.dumps(changes))
+    for rev, snapshot in snapshots.items():
+        (product_dir / f"{rev}.json").write_bytes(orjson.dumps(snapshot))
+    return product_dir
 
 
 def _make_event(**overrides):
@@ -98,3 +111,160 @@ class TestStoreRevisionEvents:
         )
 
         mock_client.put_object.assert_not_called()
+
+
+class TestIterBackfillEvents:
+    def test_add_then_change_across_two_revisions(self, tmp_path):
+        """Each revision yields one row per changed field, with resolved values."""
+        products_dir = tmp_path / "products"
+        _make_product(
+            products_dir,
+            "200/000/000/1",
+            changes=[
+                {
+                    "rev": 1,
+                    "t": 100,
+                    "comment": "created",
+                    "diffs": {"fields": {"add": ["brands"]}},
+                },
+                {
+                    "rev": 2,
+                    "t": 200,
+                    "comment": "update brands",
+                    "diffs": {"fields": {"change": ["brands"]}},
+                },
+            ],
+            snapshots={
+                1: {"code": "2000000001", "product_type": "food", "brands": "Nestlé"},
+                2: {
+                    "code": "2000000001",
+                    "product_type": "food",
+                    "brands": "Nestlé,Nescafé",
+                },
+            },
+        )
+
+        events = list(iter_backfill_events(products_dir))
+
+        assert events == [
+            {
+                "id": "2000000001_1",
+                "code": "2000000001",
+                "rev_id": 1,
+                "timestamp": 100,
+                "product_type": "food",
+                "comment": "created",
+                "field": "brands",
+                "previous": None,
+                "current": "Nestlé",
+                "action": "add",
+            },
+            {
+                "id": "2000000001_2",
+                "code": "2000000001",
+                "rev_id": 2,
+                "timestamp": 200,
+                "product_type": "food",
+                "comment": "update brands",
+                "field": "brands",
+                "previous": "Nestlé",
+                "current": "Nestlé,Nescafé",
+                "action": "change",
+            },
+        ]
+
+    def test_truncated_history_has_no_previous(self, tmp_path):
+        """When the previous snapshot is missing, `previous` is left empty."""
+        products_dir = tmp_path / "products"
+        _make_product(
+            products_dir,
+            "200/000/000/2",
+            changes=[
+                {
+                    "rev": 189,
+                    "t": 300,
+                    "comment": "first kept revision",
+                    "diffs": {"fields": {"change": ["brands"]}},
+                }
+            ],
+            snapshots={189: {"code": "2000000002", "brands": "Nestlé"}},
+        )
+
+        events = list(iter_backfill_events(products_dir))
+
+        assert len(events) == 1
+        assert events[0]["previous"] is None
+        assert events[0]["current"] == "Nestlé"
+
+    def test_contributor_field_values_are_stripped(self, tmp_path):
+        """A changed contributor field carries no user id (stripped from snapshots)."""
+        products_dir = tmp_path / "products"
+        _make_product(
+            products_dir,
+            "200/000/000/3",
+            changes=[
+                {
+                    "rev": 2,
+                    "t": 400,
+                    "comment": "edit",
+                    "diffs": {"fields": {"change": ["last_editor"]}},
+                }
+            ],
+            snapshots={
+                1: {"code": "2000000003", "last_editor": "user_a"},
+                2: {"code": "2000000003", "last_editor": "user_b"},
+            },
+        )
+
+        events = list(iter_backfill_events(products_dir))
+
+        assert len(events) == 1
+        assert events[0]["field"] == "last_editor"
+        assert events[0]["previous"] is None
+        assert events[0]["current"] is None
+
+    def test_missing_snapshot_is_skipped(self, tmp_path):
+        """A change record without its snapshot is skipped, not fatal."""
+        products_dir = tmp_path / "products"
+        _make_product(
+            products_dir,
+            "200/000/000/4",
+            changes=[
+                {
+                    "rev": 1,
+                    "t": 500,
+                    "comment": "created",
+                    "diffs": {"fields": {"add": ["brands"]}},
+                }
+            ],
+            snapshots={},
+        )
+
+        assert list(iter_backfill_events(products_dir)) == []
+
+
+class TestBackfillHistoricalEventsToFile:
+    def test_round_trip(self, tmp_path):
+        """The written dump matches the generated event rows, one JSON per line."""
+        products_dir = tmp_path / "products"
+        _make_product(
+            products_dir,
+            "200/000/000/1",
+            changes=[
+                {
+                    "rev": 1,
+                    "t": 100,
+                    "comment": "created",
+                    "diffs": {"fields": {"add": ["brands"]}},
+                }
+            ],
+            snapshots={1: {"code": "2000000001", "brands": "Nestlé"}},
+        )
+        output_path = tmp_path / "openfoodfacts_historical_events.jsonl.gz"
+
+        backfill_historical_events_to_file(products_dir, output_path)
+
+        with gzip.open(output_path, "rb") as fp:
+            rows = [orjson.loads(line) for line in fp.read().splitlines()]
+        assert rows == list(iter_backfill_events(products_dir))
+        assert rows[0]["id"] == "2000000001_1"

--- a/tests/unit/tasks/test_historical_events.py
+++ b/tests/unit/tasks/test_historical_events.py
@@ -8,9 +8,13 @@ from openfoodfacts import APIVersion
 from openfoodfacts_exports.tasks.historical_events import (
     backfill_historical_events_to_file,
     generate_events_path,
+    generate_historical_events_dump,
     iter_backfill_events,
+    publish_historical_events_dump,
     store_revision_events,
 )
+
+_MODULE = "openfoodfacts_exports.tasks.historical_events"
 
 
 def _make_product(products_dir, rel_dir, changes, snapshots):
@@ -268,3 +272,59 @@ class TestBackfillHistoricalEventsToFile:
             rows = [orjson.loads(line) for line in fp.read().splitlines()]
         assert rows == list(iter_backfill_events(products_dir))
         assert rows[0]["id"] == "2000000001_1"
+
+
+class TestGenerateHistoricalEventsDump:
+    def test_concatenates_stored_objects(self, tmp_path, mocker):
+        """Every stored event object is streamed into a single gzipped JSONL file."""
+        obj1 = mocker.MagicMock(object_name="historical_events/v2/1/1.jsonl")
+        obj2 = mocker.MagicMock(object_name="historical_events/v2/1/2.jsonl")
+        response1 = mocker.MagicMock()
+        response1.read.return_value = b'{"id": "1_1", "field": "brands"}\n'
+        response2 = mocker.MagicMock()
+        response2.read.return_value = b'{"id": "1_2", "field": "labels"}\n'
+        mock_client = mocker.MagicMock()
+        mock_client.list_objects.return_value = [obj1, obj2]
+        mock_client.get_object.side_effect = [response1, response2]
+        output_path = tmp_path / "openfoodfacts_historical_events.jsonl.gz"
+
+        generate_historical_events_dump(mock_client, output_path)
+
+        with gzip.open(output_path, "rb") as fp:
+            rows = [orjson.loads(line) for line in fp.read().splitlines()]
+        assert rows == [
+            {"id": "1_1", "field": "brands"},
+            {"id": "1_2", "field": "labels"},
+        ]
+        list_call = mock_client.list_objects.call_args
+        assert list_call.args[0] == "openfoodfacts-product-revisions"
+        assert list_call.kwargs["prefix"] == "historical_events/"
+        response1.close.assert_called_once()
+        response1.release_conn.assert_called_once()
+
+
+class TestPublishHistoricalEventsDump:
+    def test_uploads_dump_when_s3_enabled(self, mocker):
+        """When S3 push is enabled, the dump is uploaded to the dataset bucket."""
+        mock_client = mocker.MagicMock()
+        mocker.patch(f"{_MODULE}.get_minio_client", return_value=mock_client)
+        mocker.patch(f"{_MODULE}.generate_historical_events_dump")
+        mocker.patch(f"{_MODULE}.settings.ENABLE_S3_PUSH", 1)
+
+        publish_historical_events_dump()
+
+        mock_client.fput_object.assert_called_once()
+        args = mock_client.fput_object.call_args
+        assert args.args[0] == "openfoodfacts-ds"
+        assert args.args[1] == "openfoodfacts_historical_events.jsonl.gz"
+
+    def test_skips_upload_when_s3_disabled(self, mocker):
+        """When S3 push is disabled, nothing is uploaded."""
+        mock_client = mocker.MagicMock()
+        mocker.patch(f"{_MODULE}.get_minio_client", return_value=mock_client)
+        mocker.patch(f"{_MODULE}.generate_historical_events_dump")
+        mocker.patch(f"{_MODULE}.settings.ENABLE_S3_PUSH", 0)
+
+        publish_historical_events_dump()
+
+        mock_client.fput_object.assert_not_called()

--- a/tests/unit/tasks/test_revisions.py
+++ b/tests/unit/tasks/test_revisions.py
@@ -1,10 +1,53 @@
 import json
 
 import orjson
+from minio.error import S3Error
 from openfoodfacts import APIVersion
 
 from openfoodfacts_exports.tasks import revisions
 from openfoodfacts_exports.tasks.revisions import strip_product_from_user_ids
+
+
+class TestGetRevision:
+    _BARCODE = "3270160396337"
+    _API_VERSION = APIVersion.v2
+
+    def test_returns_parsed_revision(self, mocker):
+        product = {"rev": 12, "code": self._BARCODE}
+        mock_response = mocker.MagicMock()
+        mock_response.read.return_value = orjson.dumps(product)
+        mock_client = mocker.MagicMock()
+        mock_client.get_object.return_value = mock_response
+
+        result = revisions.get_revision(
+            mock_client, self._API_VERSION, self._BARCODE, "latest"
+        )
+
+        assert result == product
+        assert (
+            mock_client.get_object.call_args.kwargs["object_name"]
+            == f"v2/{self._BARCODE}/latest.json"
+        )
+        # The response is always released, even on the happy path.
+        mock_response.close.assert_called_once()
+        mock_response.release_conn.assert_called_once()
+
+    def test_returns_none_when_missing(self, mocker):
+        mock_client = mocker.MagicMock()
+        mock_client.get_object.side_effect = S3Error(
+            "NoSuchKey",
+            "The specified key does not exist.",
+            f"v2/{self._BARCODE}/11.json",
+            "request-id",
+            "host-id",
+            mocker.MagicMock(),
+        )
+
+        result = revisions.get_revision(
+            mock_client, self._API_VERSION, self._BARCODE, 11
+        )
+
+        assert result is None
 
 
 class TestUploadRevision:


### PR DESCRIPTION
### What

This finishes the historical events pipeline from #70. The offline generator
merged in #81 (v0.9.0) is now wired end to end, in 3 atomic commits.

- **Live capture.** On each product update, the Redis listener computes the
  field-level events for the new revision and stores them on S3 (JSONL), next to
  the raw revision snapshots from #77, under a `historical_events/` prefix. The
  previous revision is read from `latest.json` before it is overwritten, to
  resolve the "previous" value of each changed field. Both revisions are already
  stripped of user IDs, so no contributor data is stored. A diff failure is
  caught and logged, and never breaks the revision capture.
- **Backfill.** A new offline command rebuilds the events for every past revision
  from a bundled `products/` directory (JSON format, after the STO to JSON
  migration), so the dump is not limited to updates seen live. For each revision
  the changed fields come from `changes.json`, and the previous and current
  values are read from the `{rev-1}.json` and `{rev}.json` snapshots. Snapshots
  are stripped of user IDs. A missing snapshot or a bad record is logged and
  skipped, never fatal.
- **Nightly publication.** The stored event rows are concatenated into a single
  gzipped JSONL file and pushed to `s3://openfoodfacts-ds/`
  (`openfoodfacts_historical_events.jsonl.gz`), next to the other exports. The
  upload is gated by `ENABLE_S3_PUSH`, and wired into the scheduler as a nightly
  cron job.

Each row is one field change, in the flat denormalized format we agreed on:
`{"id": "{code}_{rev}", "code", "rev_id", "timestamp", "product_type",
"comment", "field", "previous", "current", "action"}`. It imports cleanly as
parquet and can be analysed offline with duckdb.

**Reuse and conventions.** Built on the existing code, no new dependency: the
pure generator from #81 (`generate_events`, `flatten_diffs`, `RevisionInfo`,
`write_events_jsonl_gz`), the #77 revision sync and S3 layout
(`sync_product_revision`, `generate_revision_path`,
`strip_product_from_user_ids`, the Minio client), the existing S3 publication
pattern (`ENABLE_S3_PUSH` + `fput_object` to `AWS_S3_DATASET_BUCKET`), the
scheduler and the typer CLI.

**Tests.** Unit tests for all the new code (live capture, backfill, nightly
concatenation and upload), including the truncated history case and a check that
contributor field values are stripped. `ruff` and `mypy` are clean on the
changed files.

**New CLI commands.** `backfill-historical-events <products_dir> <output_path>`
and `publish-historical-events`.

**A few points I would like your input on:**

1. **Backfill source.** I read the backlog from a bundled `products/` directory
   (`changes.json` + `{rev}.json`). The reading is isolated in
   `iter_backfill_events`, so if you prefer to source it from the API (uniform
   schema), only that function changes.
2. **Merging backfill and live.** The nightly job concatenates the S3 rows fed by
   the live listener. How would you like the backfill output to feed the same
   store, or be merged into the published file?
3. **Nightly cost.** Concatenating a very large number of small S3 objects every
   night is heavy. We could add incremental compaction later.

### Screenshot

No UI. This is a backend export that produces a public dataset, so there is
nothing to show.

### Fixes bug(s)

- None, this is a feature.

### Part of

- #70